### PR TITLE
Pin cargo-wix to 0.3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          cargo install cargo-wix --version 0.3 --locked
+          cargo install cargo-wix --version '^0.3' --locked
           # Build the MSI from the committed wix/main.wxs. Do NOT run
           # `cargo wix init --force`, which regenerates main.wxs from the stock
           # template and discards the checked-in Start-Menu shortcut, ARP icon,


### PR DESCRIPTION
`cargo install cargo-wix --version 0.3` is rejected by current cargo (`unexpected end of input while parsing minor version number`), so the v0.3.4 Windows MSI never built.

Pin 0.3.9.