### PR TITLE
Harden file operations and background work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ users = "0.11"
 # subsystem apps have no attached stderr, so without this the user just
 # sees the window fail to appear with no explanation.
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }
+windows-sys = { version = "0.59", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [package.metadata.deb]
 maintainer = "Dzmitry Malyshau"

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -555,6 +555,7 @@ pub struct AppState {
     pub search_results: Vec<SearchResult>,
     pub search_selected: usize,
     pub search_request_id: u64,
+    pub search_cancel: Arc<std::sync::atomic::AtomicBool>,
     /// The (panel, tab) that started the current search. Search events are
     /// routed here rather than to whatever panel/tab happens to be active when
     /// they arrive, so switching panels or tabs mid-search doesn't inject

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -750,6 +750,21 @@ impl AppState {
         }
     }
 
+    /// Native close must not discard an edit or abandon an active operation.
+    pub fn quit_blocker(&self) -> Option<&'static str> {
+        for panel in [&self.left_panel, &self.right_panel] {
+            if let PanelMode::Edit(ref edit) = panel.mode
+                && edit.dirty
+            {
+                return Some("Save or discard the edited file before closing FileMan.");
+            }
+        }
+        if self.io_in_flight > 0 {
+            return Some("Finish or cancel the file operation before closing FileMan.");
+        }
+        None
+    }
+
     pub fn props_dialog(&self) -> Option<&PropsDialog> {
         match self.modal {
             Some(Modal::Props(ref d)) => Some(d),

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -52,7 +52,11 @@ impl PanelState {
             browser_mode: current.browser_mode.clone(),
             current_path: current.current_path.clone(),
             selected_index: 0,
-            entries: Vec::new(),
+            entries: if matches!(current.browser_mode, BrowserMode::Search { .. }) {
+                current.entries.clone()
+            } else {
+                Vec::new()
+            },
             load: LoadState::Idle,
             progress_override: None,
             prefer_select_name: None,
@@ -400,6 +404,26 @@ pub struct PanelSnapshot {
     pub mode: BrowserMode,
     pub current_path: path::PathBuf,
     pub selected_name: Option<String>,
+    /// A search belongs to this history entry, not to the latest global query.
+    pub search_entries: Option<Arc<[DirEntry]>>,
+}
+
+impl PanelSnapshot {
+    pub fn capture(browser: &BrowserState) -> Self {
+        let search = matches!(browser.browser_mode, BrowserMode::Search { .. });
+        let selected_name = browser.entries.get(browser.selected_index).map(|entry| {
+            if search && let EntryLocation::Fs(ref path) = entry.location {
+                return format!("fs:{}", path.to_string_lossy());
+            }
+            entry.name.clone()
+        });
+        Self {
+            mode: browser.browser_mode.clone(),
+            current_path: browser.current_path.clone(),
+            selected_name,
+            search_entries: search.then(|| Arc::from(browser.entries.clone())),
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -1081,19 +1105,7 @@ impl AppState {
         let snapshot = {
             let panel = self.panel(which);
             let browser = panel.browser();
-            let selected = browser.entries.get(browser.selected_index).map(|e| {
-                if matches!(browser.browser_mode, BrowserMode::Search { .. })
-                    && let EntryLocation::Fs(path) = e.location.clone()
-                {
-                    return format!("fs:{}", path.to_string_lossy());
-                }
-                e.name.clone()
-            });
-            PanelSnapshot {
-                mode: browser.browser_mode.clone(),
-                current_path: browser.current_path.clone(),
-                selected_name: selected,
-            }
+            PanelSnapshot::capture(browser)
         };
         let panel = self.panel_mut(which);
         let browser = panel.browser_mut();
@@ -1110,19 +1122,7 @@ impl AppState {
         let current = {
             let panel = self.panel(which);
             let browser = panel.browser();
-            let selected = browser.entries.get(browser.selected_index).map(|e| {
-                if matches!(browser.browser_mode, BrowserMode::Search { .. })
-                    && let EntryLocation::Fs(path) = e.location.clone()
-                {
-                    return format!("fs:{}", path.to_string_lossy());
-                }
-                e.name.clone()
-            });
-            PanelSnapshot {
-                mode: browser.browser_mode.clone(),
-                current_path: browser.current_path.clone(),
-                selected_name: selected,
-            }
+            PanelSnapshot::capture(browser)
         };
         let panel = self.panel_mut(which);
         let browser = panel.browser_mut();
@@ -1137,19 +1137,7 @@ impl AppState {
         let current = {
             let panel = self.panel(which);
             let browser = panel.browser();
-            let selected = browser.entries.get(browser.selected_index).map(|e| {
-                if matches!(browser.browser_mode, BrowserMode::Search { .. })
-                    && let EntryLocation::Fs(path) = e.location.clone()
-                {
-                    return format!("fs:{}", path.to_string_lossy());
-                }
-                e.name.clone()
-            });
-            PanelSnapshot {
-                mode: browser.browser_mode.clone(),
-                current_path: browser.current_path.clone(),
-                selected_name: selected,
-            }
+            PanelSnapshot::capture(browser)
         };
         let panel = self.panel_mut(which);
         let browser = panel.browser_mut();

--- a/src/core.rs
+++ b/src/core.rs
@@ -450,6 +450,7 @@ pub enum SearchCase {
 
 pub struct SearchRequest {
     pub id: u64,
+    pub cancel: Arc<std::sync::atomic::AtomicBool>,
     pub root: path::PathBuf,
     pub needle: String,
     pub case: SearchCase,

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,6 +9,9 @@ use std::{
     time::UNIX_EPOCH,
 };
 
+#[path = "file_identity.rs"]
+mod file_identity;
+
 /// Shared transfer progress, updated atomically by worker threads and read by
 /// the UI. One instance lives in AppState behind an Arc.
 pub struct TransferProgress {
@@ -530,6 +533,12 @@ pub fn copy_recursively(src: &Path, dst_dir: &Path) -> io::Result<()> {
     }
 
     let meta = fs::symlink_metadata(src)?;
+    if meta.is_file() && file_identity::same_file(src, &dest)? {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "source and destination are the same file",
+        ));
+    }
 
     if meta.file_type().is_symlink() {
         #[cfg(unix)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -900,12 +900,10 @@ pub fn format_date(epoch_secs: u64) -> String {
 }
 
 pub fn format_mode(mode: u32) -> String {
-    let file_type = if mode & 0o40000 != 0 {
-        'd'
-    } else if mode & 0o120000 != 0 {
-        'l'
-    } else {
-        '-'
+    let file_type = match mode & 0o170000 {
+        0o040000 => 'd',
+        0o120000 => 'l',
+        _ => '-',
     };
     let mut out = String::with_capacity(10);
     out.push(file_type);

--- a/src/file_identity.rs
+++ b/src/file_identity.rs
@@ -1,0 +1,59 @@
+//! File identity checks before an overwrite. Paths alone miss hard links.
+
+use std::{fs, io, path};
+
+pub(super) fn same_file(source: &path::Path, destination: &path::Path) -> io::Result<bool> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        let source = fs::metadata(source)?;
+        let destination = match fs::metadata(destination) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        Ok(source.dev() == destination.dev() && source.ino() == destination.ino())
+    }
+    #[cfg(windows)]
+    {
+        Ok(Some(identity(source)?)
+            == match identity(destination) {
+                Ok(id) => Some(id),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+                Err(error) => return Err(error),
+            })
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let source = fs::canonicalize(source)?;
+        match fs::canonicalize(destination) {
+            Ok(destination) => Ok(source == destination),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn identity(path: &path::Path) -> io::Result<(u32, u32, u32)> {
+    use std::os::windows::{fs::OpenOptionsExt as _, io::AsRawHandle as _};
+    use windows_sys::Win32::Storage::FileSystem as win;
+
+    // Query metadata without requiring read access to the file's contents.
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .access_mode(0)
+        .custom_flags(win::FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?;
+    // SAFETY: this POD structure is initialized and writable; File owns a live
+    // handle for the duration of the call.
+    let mut info: win::BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+    if unsafe { win::GetFileInformationByHandle(file.as_raw_handle(), &mut info) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok((
+        info.dwVolumeSerialNumber,
+        info.nFileIndexHigh,
+        info.nFileIndexLow,
+    ))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3457,6 +3457,7 @@ struct Runtime {
     surface_info: blade_graphics::SurfaceInfo,
     command_encoder: blade_graphics::CommandEncoder,
     last_sync: Option<blade_graphics::SyncPoint>,
+    pending_view: Option<bg::TextureView>,
     egui_ctx: egui::Context,
     egui_state: egui_winit::State,
     painter: be::GuiPainter,
@@ -3478,6 +3479,19 @@ struct Runtime {
 }
 
 impl Runtime {
+    fn finish_frame(&mut self) -> Result<(), String> {
+        if let Some(ref sync) = self.last_sync {
+            self.context
+                .wait_for(sync, !0)
+                .map_err(|error| format!("GPU frame wait failed: {error:?}"))?;
+        }
+        if let Some(view) = self.pending_view.take() {
+            self.context.destroy_texture_view(view);
+        }
+        self.last_sync = None;
+        Ok(())
+    }
+
     fn shutdown(&mut self) {
         self.image_cache.textures.clear();
         self.image_cache.meta.clear();
@@ -3487,8 +3501,9 @@ impl Runtime {
         self.image_cache.refining.clear();
         self.highlight_cache.clear();
         self.highlight_pending.clear();
-        if let Some(sync) = self.last_sync.take() {
-            self.context.wait_for(&sync, !0).ok();
+        if let Err(error) = self.finish_frame() {
+            log::error!("{error}");
+            return;
         }
         self.context
             .destroy_command_encoder(&mut self.command_encoder);
@@ -4181,6 +4196,7 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
             surface_info,
             command_encoder,
             last_sync: None,
+            pending_view: None,
             egui_ctx,
             egui_state,
             painter,
@@ -4214,6 +4230,9 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
 
         match event {
             winit::event::WindowEvent::RedrawRequested => {
+                if runtime.size.width == 0 || runtime.size.height == 0 {
+                    return;
+                }
                 let transfer_progress = runtime.app.transfer_progress.clone();
                 let mut highlight_updated = false;
                 let mut completed = 0usize;
@@ -4722,8 +4741,10 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
                     scale_factor: runtime.window.scale_factor() as f32,
                 };
 
-                if let Some(sync) = runtime.last_sync.take() {
-                    runtime.context.wait_for(&sync, !0).ok();
+                if let Err(error) = runtime.finish_frame() {
+                    fatal_error_dialog("FileMan: GPU error", &error);
+                    event_loop.exit();
+                    return;
                 }
                 runtime.command_encoder.start();
                 runtime.painter.update_textures(
@@ -4767,7 +4788,7 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
                 let sync = runtime.context.submit(&mut runtime.command_encoder);
                 runtime.last_sync = Some(sync.clone());
                 runtime.painter.after_submit(&sync);
-                runtime.context.destroy_texture_view(view);
+                runtime.pending_view = Some(view);
                 if highlight_updated {
                     runtime.window.request_redraw();
                 }
@@ -4797,6 +4818,14 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
                     }
                     winit::event::WindowEvent::Resized(new_size) => {
                         runtime.size = new_size;
+                        if new_size.width == 0 || new_size.height == 0 {
+                            return;
+                        }
+                        if let Err(error) = runtime.finish_frame() {
+                            fatal_error_dialog("FileMan: GPU error", &error);
+                            event_loop.exit();
+                            return;
+                        }
                         runtime.surface_config.size = bg::Extent {
                             width: runtime.size.width.max(1),
                             height: runtime.size.height.max(1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3103,6 +3103,8 @@ fn apply_panel_snapshot(
 }
 
 fn cancel_search(app: &mut app_state::AppState) {
+    app.search_cancel
+        .store(true, std::sync::atomic::Ordering::Relaxed);
     app.search_request_id = app.search_request_id.wrapping_add(1);
     app.search_status = app_state::SearchStatus::Idle;
 }
@@ -3114,6 +3116,9 @@ fn start_search(app: &mut app_state::AppState) {
     }
     let search_mode = app.search_mode;
     let search_case = app.search_case;
+    app.search_cancel
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    app.search_cancel = Default::default();
     let id = app.search_request_id.wrapping_add(1);
     app.search_request_id = id;
     app.search_target = Some((app.active_panel, app.get_active_panel().active_tab));
@@ -3156,6 +3161,7 @@ fn start_search(app: &mut app_state::AppState) {
     }
     let _ = app.search_tx.send(core::SearchRequest {
         id,
+        cancel: Arc::clone(&app.search_cancel),
         root,
         needle,
         case: search_case,
@@ -3493,6 +3499,9 @@ impl Runtime {
     }
 
     fn shutdown(&mut self) {
+        self.app
+            .search_cancel
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         self.image_cache.textures.clear();
         self.image_cache.meta.clear();
         self.image_cache.failures.clear();
@@ -4100,6 +4109,7 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
             search_results: Vec::new(),
             search_selected: 0,
             search_request_id: 0,
+            search_cancel: Default::default(),
             search_target: None,
             search_status: app_state::SearchStatus::Idle,
             search_ui: app_state::SearchUiState::Closed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -809,49 +809,6 @@ fn sort_mode_label(mode: core::SortMode) -> &'static str {
     }
 }
 
-fn rebuild_search_entries(browser: &mut app_state::BrowserState, results: &[core::SearchResult]) {
-    let app_state::BrowserState {
-        browser_mode: ref mode,
-        ..
-    } = *browser;
-    browser.entries = results
-        .iter()
-        .map(|result| {
-            let display_name = match mode {
-                core::BrowserMode::Search { root, .. } => result
-                    .path
-                    .strip_prefix(root)
-                    .ok()
-                    .and_then(|p| p.to_str())
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| {
-                        result
-                            .path
-                            .file_name()
-                            .and_then(|s| s.to_str())
-                            .unwrap_or("<unknown>")
-                            .to_string()
-                    }),
-                _ => result
-                    .path
-                    .file_name()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("<unknown>")
-                    .to_string(),
-            };
-            core::DirEntry {
-                name: display_name,
-                is_dir: result.is_dir,
-                is_symlink: false,
-                link_target: None,
-                location: core::EntryLocation::Fs(result.path.clone()),
-                size: result.size,
-                modified: result.modified,
-            }
-        })
-        .collect();
-}
-
 fn hexdump_job(
     bytes: &[u8],
     width: usize,
@@ -3009,6 +2966,10 @@ fn apply_panel_snapshot(
     which: core::ActivePanel,
     snapshot: fileman::app_state::PanelSnapshot,
 ) {
+    if app.search_target == Some((which, app.panel(which).active_tab)) {
+        cancel_search(app);
+        app.search_target = None;
+    }
     match snapshot.mode {
         core::BrowserMode::Fs => {
             load_fs_directory_async(app, snapshot.current_path, which, snapshot.selected_name);
@@ -3035,49 +2996,15 @@ fn apply_panel_snapshot(
             load_sftp_directory_async(app, host, path, which, snapshot.selected_name);
         }
         core::BrowserMode::Search { .. } => {
-            let results = app.search_results.clone();
             let panel = app.panel_mut(which);
             let browser = panel.browser_mut();
             browser.browser_mode = snapshot.mode;
             browser.current_path = snapshot.current_path;
-            browser.entries.clear();
-            browser.entries.extend(results.iter().map(|result| {
-                let app_state::BrowserState {
-                    browser_mode: ref mode,
-                    ..
-                } = *browser;
-                let display_name = match mode {
-                    core::BrowserMode::Search { root, .. } => result
-                        .path
-                        .strip_prefix(root)
-                        .ok()
-                        .and_then(|p| p.to_str())
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| {
-                            result
-                                .path
-                                .file_name()
-                                .and_then(|s| s.to_str())
-                                .unwrap_or("<unknown>")
-                                .to_string()
-                        }),
-                    _ => result
-                        .path
-                        .file_name()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("<unknown>")
-                        .to_string(),
-                };
-                core::DirEntry {
-                    name: display_name,
-                    is_dir: result.is_dir,
-                    is_symlink: false,
-                    link_target: None,
-                    location: core::EntryLocation::Fs(result.path.clone()),
-                    size: result.size,
-                    modified: result.modified,
-                }
-            }));
+            browser.entries = snapshot
+                .search_entries
+                .as_deref()
+                .unwrap_or_default()
+                .to_vec();
             sort_entries(&mut browser.entries, browser.sort_mode, browser.sort_desc);
             browser.load = app_state::LoadState::Idle;
             browser.selected_index = snapshot
@@ -3287,10 +3214,9 @@ fn reload_panel(app: &mut app_state::AppState, which: core::ActivePanel) {
             load_sftp_directory_async(app, host, path, which, selected_name);
         }
         core::BrowserMode::Search { .. } => {
-            let results = app.search_results.clone();
             let panel = app.panel_mut(which);
             let browser = panel.browser_mut();
-            rebuild_search_entries(browser, &results);
+            sort_entries(&mut browser.entries, browser.sort_mode, browser.sort_desc);
             if let Some(name) = selected_name
                 && let Some(idx) = browser.entries.iter().position(|entry| entry.name == name)
             {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4827,8 +4827,13 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
 
                 match other {
                     winit::event::WindowEvent::CloseRequested => {
-                        // SFTP sessions are dropped automatically
-                        event_loop.exit();
+                        if let Some(message) = runtime.app.quit_blocker() {
+                            runtime.app.record_error("quit", message);
+                            runtime.needs_redraw = true;
+                            runtime.window.request_redraw();
+                        } else {
+                            event_loop.exit();
+                        }
                     }
                     winit::event::WindowEvent::Resized(new_size) => {
                         runtime.size = new_size;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4339,6 +4339,10 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
                                     |t| now.duration_since(*t) < MIN_REFINING_DISPLAY,
                                 ) =>
                             {
+                                let elapsed = runtime.image_cache.refining[&inner.key].elapsed();
+                                ctx.request_repaint_after(
+                                    MIN_REFINING_DISPLAY.saturating_sub(elapsed),
+                                );
                                 runtime.image_pending.push_back(decoded);
                                 continue;
                             }
@@ -4862,21 +4866,6 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
             }
             if !runtime.highlight_results.is_empty() {
                 runtime.window.request_redraw();
-            }
-            if let Some(preview) = runtime.app.preview_panel_mut()
-                && let Some(core::PreviewContent::Image(path)) = preview.content.as_ref()
-            {
-                let key = image_cache_key(path);
-                // Keep repainting only while the decode is unresolved: still in
-                // flight (animate the spinner), or not yet dispatched. Once the
-                // key resolves to a texture OR a failure, stop — otherwise a
-                // decode failure (key in `failures`, never in `textures`) would
-                // force a redraw every frame forever, pinning the CPU/GPU.
-                let resolved = runtime.image_cache.textures.contains_key(&key)
-                    || runtime.image_cache.failures.contains_key(&key);
-                if runtime.image_cache.pending.contains(&key) || !resolved {
-                    runtime.needs_redraw = true;
-                }
             }
             if pump_async(&mut runtime.app) {
                 runtime.needs_redraw = true;

--- a/src/replay_runner.rs
+++ b/src/replay_runner.rs
@@ -478,6 +478,7 @@ fn init_headless_app(root: Option<PathBuf>) -> anyhow::Result<app_state::AppStat
         search_results: Vec::new(),
         search_selected: 0,
         search_request_id: 0,
+        search_cancel: Default::default(),
         search_target: None,
         search_status: app_state::SearchStatus::Idle,
         search_ui: app_state::SearchUiState::Closed,

--- a/src/search_scan.rs
+++ b/src/search_scan.rs
@@ -1,0 +1,143 @@
+//! Bounded, cancellable content scanning. The buffers are reused between reads.
+
+use std::{io, path, sync::atomic};
+
+use crate::core::SearchCase;
+
+const CHUNK: usize = 64 * 1024;
+
+fn check_cancelled(cancel: &atomic::AtomicBool) -> io::Result<()> {
+    if cancel.load(atomic::Ordering::Relaxed) {
+        Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "search cancelled",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub(super) fn file_contains(
+    path: &path::Path,
+    needle: &str,
+    case: SearchCase,
+    cancel: &atomic::AtomicBool,
+) -> io::Result<bool> {
+    check_cancelled(cancel)?;
+    let mut file = std::fs::File::open(path)?;
+    reader_contains(&mut file, needle, case, cancel)
+}
+
+fn reader_contains(
+    reader: &mut impl io::Read,
+    needle: &str,
+    case: SearchCase,
+    cancel: &atomic::AtomicBool,
+) -> io::Result<bool> {
+    if needle.is_empty() {
+        return Ok(false);
+    }
+    let needle = match case {
+        SearchCase::Sensitive => needle.as_bytes().to_vec(),
+        SearchCase::Insensitive => needle.to_ascii_lowercase().into_bytes(),
+    };
+    let mut chunk = vec![0; CHUNK];
+    let mut window = Vec::new();
+    loop {
+        check_cancelled(cancel)?;
+        let read = match reader.read(&mut chunk) {
+            Ok(read) => read,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        check_cancelled(cancel)?;
+        if read == 0 {
+            return Ok(false);
+        }
+        window.extend_from_slice(&chunk[..read]);
+        if case == SearchCase::Insensitive {
+            window.make_ascii_lowercase();
+        }
+        if memchr::memmem::find(&window, &needle).is_some() {
+            return Ok(true);
+        }
+        // Keep enough overlap for matches crossing an arbitrary read boundary.
+        let keep = needle.len().saturating_sub(1).min(window.len());
+        let start = window.len() - keep;
+        window.copy_within(start.., 0);
+        window.truncate(keep);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct CancellingReader<'a> {
+        cancel: &'a atomic::AtomicBool,
+        reads: usize,
+    }
+
+    impl io::Read for CancellingReader<'_> {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            self.reads += 1;
+            buffer.fill(b'x');
+            self.cancel.store(true, atomic::Ordering::Relaxed);
+            Ok(buffer.len())
+        }
+    }
+
+    #[test]
+    fn cancellation_stops_before_the_next_read() {
+        let cancel = atomic::AtomicBool::new(false);
+        let mut reader = CancellingReader {
+            cancel: &cancel,
+            reads: 0,
+        };
+        let error =
+            reader_contains(&mut reader, "absent", SearchCase::Sensitive, &cancel).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Interrupted);
+        assert_eq!(reader.reads, 1);
+    }
+
+    #[test]
+    fn a_cancelled_request_does_not_read() {
+        let cancel = atomic::AtomicBool::new(true);
+        let mut reader = CancellingReader {
+            cancel: &cancel,
+            reads: 0,
+        };
+        assert!(reader_contains(&mut reader, "x", SearchCase::Sensitive, &cancel).is_err());
+        assert_eq!(reader.reads, 0);
+    }
+
+    #[test]
+    fn matches_across_chunk_boundaries() {
+        let cancel = atomic::AtomicBool::new(false);
+        let mut bytes = vec![b'x'; CHUNK - 2];
+        bytes.extend_from_slice(b"NeEdLe");
+        let mut reader = io::Cursor::new(bytes);
+        assert!(reader_contains(&mut reader, "needle", SearchCase::Insensitive, &cancel).unwrap());
+        reader.set_position(0);
+        assert!(!reader_contains(&mut reader, "needle", SearchCase::Sensitive, &cancel).unwrap());
+    }
+
+    #[test]
+    fn supports_needles_larger_than_a_chunk() {
+        let cancel = atomic::AtomicBool::new(false);
+        let needle = "a".repeat(CHUNK + 7);
+        let mut reader = io::Cursor::new(needle.as_bytes());
+        assert!(reader_contains(&mut reader, &needle, SearchCase::Sensitive, &cancel).unwrap());
+    }
+
+    #[test]
+    fn empty_needle_does_not_read() {
+        let cancel = atomic::AtomicBool::new(false);
+        let mut reader = CancellingReader {
+            cancel: &cancel,
+            reads: 0,
+        };
+        assert!(!reader_contains(&mut reader, "", SearchCase::Sensitive, &cancel).unwrap());
+        assert_eq!(reader.reads, 0);
+    }
+}

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -1,0 +1,93 @@
+//! An exclusively created staging directory, removed when its job finishes.
+
+use std::{fs, io, path, sync::atomic};
+
+pub(super) struct TempDir(path::PathBuf);
+
+impl TempDir {
+    pub(super) fn new() -> io::Result<Self> {
+        static NEXT: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+        for _ in 0..128 {
+            let id = NEXT.fetch_add(1, atomic::Ordering::Relaxed);
+            let path =
+                std::env::temp_dir().join(format!("fileman-upload-{}-{id}", std::process::id()));
+            #[cfg_attr(not(unix), allow(unused_mut))]
+            let mut builder = fs::DirBuilder::new();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::DirBuilderExt as _;
+                builder.mode(0o700);
+            }
+            match builder.create(&path) {
+                Ok(()) => return Ok(Self(path)),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "cannot allocate staging directory",
+        ))
+    }
+
+    pub(super) fn path(&self) -> &path::Path {
+        &self.0
+    }
+
+    pub(super) fn child(&self, name: &str) -> io::Result<path::PathBuf> {
+        let name = path::Path::new(name);
+        if name.file_name() != Some(name.as_os_str()) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid staging filename",
+            ));
+        }
+        Ok(self.0.join(name))
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_dir_all(&self.0) {
+            log::debug!("staging cleanup failed: {error}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jobs_do_not_share_staging_and_cleanup_is_scoped() {
+        let first = TempDir::new().unwrap();
+        let second = TempDir::new().unwrap();
+        assert_ne!(first.path(), second.path());
+        fs::write(first.child("data").unwrap(), b"first").unwrap();
+        fs::write(second.child("data").unwrap(), b"second").unwrap();
+        let path = first.path().to_owned();
+        drop(first);
+        assert!(!path.exists());
+        assert_eq!(fs::read(second.child("data").unwrap()).unwrap(), b"second");
+    }
+
+    #[test]
+    fn rejects_paths_in_place_of_a_filename() {
+        let dir = TempDir::new().unwrap();
+        for name in ["", ".", "..", "../escape", "nested/file", "/absolute"] {
+            assert!(dir.child(name).is_err(), "accepted {name:?}");
+        }
+        assert!(dir.child("file with spaces").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staging_is_private_on_unix() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = TempDir::new().unwrap();
+        assert_eq!(
+            fs::metadata(dir.path()).unwrap().permissions().mode() & 0o077,
+            0
+        );
+    }
+}

--- a/src/ui/disk_space.rs
+++ b/src/ui/disk_space.rs
@@ -1,0 +1,219 @@
+//! Demand-driven free-space cache. No filesystem calls on the drawing thread.
+
+use std::{collections, path, sync, thread, time};
+
+type Wake = sync::Arc<dyn Fn() + Send + Sync>;
+const TTL: time::Duration = time::Duration::from_secs(5);
+const MAX_ENTRIES: usize = 64;
+const MAX_PENDING: usize = 8;
+
+struct Entry {
+    value: Option<u64>,
+    sampled: Option<time::Instant>,
+    used: time::Instant,
+    pending: bool,
+}
+
+impl Entry {
+    fn fresh(&self, now: time::Instant) -> bool {
+        self.sampled
+            .is_some_and(|at| now.saturating_duration_since(at) < TTL)
+    }
+}
+
+type Entries = collections::HashMap<path::PathBuf, Entry>;
+
+struct Request {
+    path: path::PathBuf,
+    wake: Option<Wake>,
+}
+
+struct Cache {
+    entries: sync::Arc<sync::Mutex<Entries>>,
+    sender: sync::mpsc::SyncSender<Request>,
+}
+
+impl Cache {
+    fn new(query: fn(&path::Path) -> Option<u64>) -> Self {
+        let entries = sync::Arc::new(sync::Mutex::new(Entries::new()));
+        let (sender, receiver) = sync::mpsc::sync_channel::<Request>(MAX_PENDING);
+        let shared = sync::Arc::clone(&entries);
+        if let Err(error) = thread::Builder::new()
+            .name("free-space".into())
+            .spawn(move || {
+                while let Ok(request) = receiver.recv() {
+                    let value = query(&request.path);
+                    {
+                        let mut entries = shared.lock().unwrap_or_else(|error| error.into_inner());
+                        if let Some(entry) = entries.get_mut(&request.path) {
+                            entry.value = value;
+                            entry.sampled = Some(time::Instant::now());
+                            entry.pending = false;
+                        }
+                    }
+                    if let Some(wake) = request.wake {
+                        wake();
+                    }
+                }
+            })
+        {
+            log::warn!("cannot start free-space worker: {error}");
+        }
+        Self { entries, sender }
+    }
+
+    fn get(&self, path: &path::Path, wake: Option<Wake>) -> Option<u64> {
+        let now = time::Instant::now();
+        let mut entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if !entries.contains_key(path) && entries.len() >= MAX_ENTRIES {
+            let oldest = entries
+                .iter()
+                .filter(|(_, entry)| !entry.pending)
+                .min_by_key(|(_, entry)| entry.used)
+                .map(|(path, _)| path.clone());
+            entries.remove(&oldest?);
+        }
+        let entry = entries.entry(path.to_owned()).or_insert(Entry {
+            value: None,
+            sampled: None,
+            used: now,
+            pending: false,
+        });
+        entry.used = now;
+        if !entry.pending && !entry.fresh(now) {
+            entry.pending = true;
+            if self
+                .sender
+                .try_send(Request {
+                    path: path.to_owned(),
+                    wake,
+                })
+                .is_err()
+            {
+                entry.pending = false;
+            }
+        }
+        entry.value
+    }
+}
+
+pub(super) fn get(path: &path::Path, wake: Option<Wake>) -> Option<u64> {
+    static CACHE: sync::LazyLock<Cache> = sync::LazyLock::new(|| Cache::new(free_space_bytes));
+    CACHE.get(path, wake)
+}
+
+#[cfg(unix)]
+fn free_space_bytes(path: &std::path::Path) -> Option<u64> {
+    use std::os::unix::ffi::OsStrExt as _;
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).ok()?;
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) };
+    if rc != 0 {
+        return None;
+    }
+    // statvfs widths vary by platform; multiply via u128 to avoid overflow.
+    let bavail = u128::from(stat.f_bavail);
+    let frsize = u128::from(stat.f_frsize);
+    Some((bavail * frsize).min(u128::from(u64::MAX)) as u64)
+}
+
+#[cfg(windows)]
+fn free_space_bytes(path: &std::path::Path) -> Option<u64> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt as _;
+
+    unsafe extern "system" {
+        fn GetDiskFreeSpaceExW(
+            lpDirectoryName: *const u16,
+            lpFreeBytesAvailableToCaller: *mut u64,
+            lpTotalNumberOfBytes: *mut u64,
+            lpTotalNumberOfFreeBytes: *mut u64,
+        ) -> i32;
+    }
+
+    let wide: Vec<u16> = OsStr::new(path)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let mut free_available: u64 = 0;
+    let ok = unsafe {
+        GetDiskFreeSpaceExW(
+            wide.as_ptr(),
+            &mut free_available,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if ok != 0 { Some(free_available) } else { None }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn free_space_bytes(_path: &std::path::Path) -> Option<u64> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_queries_are_cached_too() {
+        let now = time::Instant::now();
+        let entry = Entry {
+            value: None,
+            sampled: Some(now),
+            used: now,
+            pending: false,
+        };
+        assert!(entry.fresh(now));
+        assert!(!entry.fresh(now + TTL));
+    }
+
+    #[test]
+    fn worker_results_are_cached_and_wake_the_ui() {
+        static RUNS: sync::atomic::AtomicUsize = sync::atomic::AtomicUsize::new(0);
+        fn query(_: &path::Path) -> Option<u64> {
+            RUNS.fetch_add(1, sync::atomic::Ordering::Relaxed);
+            Some(123)
+        }
+        let cache = Cache::new(query);
+        let (sender, receiver) = sync::mpsc::channel();
+        let wake: Wake = sync::Arc::new(move || {
+            let _ = sender.send(());
+        });
+        let path = path::Path::new("synthetic-path");
+        assert_eq!(cache.get(path, Some(wake)), None);
+        receiver.recv_timeout(time::Duration::from_secs(5)).unwrap();
+        for _ in 0..100 {
+            assert_eq!(cache.get(path, None), Some(123));
+        }
+        assert_eq!(RUNS.load(sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn cached_entries_are_bounded() {
+        let (sender, _receiver) = sync::mpsc::sync_channel(0);
+        let cache = Cache {
+            entries: Default::default(),
+            sender,
+        };
+        for i in 0..MAX_ENTRIES * 2 {
+            assert_eq!(
+                cache.get(&path::PathBuf::from(format!("path-{i}")), None),
+                None
+            );
+        }
+        assert_eq!(cache.entries.lock().unwrap().len(), MAX_ENTRIES);
+        assert!(
+            cache
+                .entries
+                .lock()
+                .unwrap()
+                .values()
+                .all(|entry| !entry.pending)
+        );
+    }
+}

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -1,5 +1,8 @@
 use std::sync::mpsc;
 
+#[path = "disk_space.rs"]
+mod disk_space;
+
 use fileman::{app_state, archive, core, theme};
 
 use crate::input::open_selected;
@@ -82,10 +85,9 @@ fn draw_status_line(
             ui.colored_label(dim, "·");
         }
 
-        // FS panels: free space on the panel's drive. Cached per-frame —
-        // statvfs is cheap on Linux/macOS.
+        // Reuse the last sample while a worker refreshes it on demand.
         if let core::BrowserMode::Fs = browser.browser_mode
-            && let Some(free) = free_space_bytes(&browser.current_path)
+            && let Some(free) = disk_space::get(&browser.current_path, app.wake.clone())
         {
             ui.colored_label(
                 fg,
@@ -125,56 +127,6 @@ fn worker_dot(ui: &mut egui::Ui, active: bool, colors: &theme::ThemeColors) {
             egui::Stroke::new(1.0_f32, color32(fade_color(colors.footer_fg, 0.5))),
         );
     }
-}
-
-#[cfg(unix)]
-fn free_space_bytes(path: &std::path::Path) -> Option<u64> {
-    use std::os::unix::ffi::OsStrExt as _;
-    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).ok()?;
-    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
-    let rc = unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) };
-    if rc != 0 {
-        return None;
-    }
-    // statvfs widths vary by platform; multiply via u128 to avoid overflow.
-    let bavail = u128::from(stat.f_bavail);
-    let frsize = u128::from(stat.f_frsize);
-    Some((bavail * frsize).min(u128::from(u64::MAX)) as u64)
-}
-
-#[cfg(windows)]
-fn free_space_bytes(path: &std::path::Path) -> Option<u64> {
-    use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt as _;
-
-    unsafe extern "system" {
-        fn GetDiskFreeSpaceExW(
-            lpDirectoryName: *const u16,
-            lpFreeBytesAvailableToCaller: *mut u64,
-            lpTotalNumberOfBytes: *mut u64,
-            lpTotalNumberOfFreeBytes: *mut u64,
-        ) -> i32;
-    }
-
-    let wide: Vec<u16> = OsStr::new(path)
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-    let mut free_available: u64 = 0;
-    let ok = unsafe {
-        GetDiskFreeSpaceExW(
-            wide.as_ptr(),
-            &mut free_available,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        )
-    };
-    if ok != 0 { Some(free_available) } else { None }
-}
-
-#[cfg(not(any(unix, windows)))]
-fn free_space_bytes(_path: &std::path::Path) -> Option<u64> {
-    None
 }
 
 fn is_executable_name(name: &str) -> bool {

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -55,6 +55,9 @@ where
     f(&locked)
 }
 
+#[path = "search_scan.rs"]
+mod search_scan;
+
 const PREVIEW_CHUNK_BYTES: usize = 16 * 1024;
 
 pub fn start_io_worker(
@@ -1405,6 +1408,9 @@ pub fn start_search_worker(
                     Err(_) => break,
                 },
             };
+            if request.cancel.load(Ordering::Relaxed) {
+                continue;
+            }
             if let Some((ref host, ref remote_root)) = request.remote {
                 pending = run_remote_search(
                     &request,
@@ -1430,6 +1436,9 @@ pub fn start_search_worker(
             let mut tick = 0usize;
 
             loop {
+                if request.cancel.load(Ordering::Relaxed) {
+                    continue 'worker;
+                }
                 if let Ok(new_request) = rx.try_recv() {
                     pending = Some(new_request);
                     continue 'worker;
@@ -1452,6 +1461,9 @@ pub fn start_search_worker(
                     Err(_) => continue,
                 };
                 for entry in read_dir.flatten() {
+                    if request.cancel.load(Ordering::Relaxed) {
+                        continue 'worker;
+                    }
                     tick = tick.wrapping_add(1);
                     if tick.is_multiple_of(256) {
                         if let Ok(new_request) = rx.try_recv() {
@@ -1521,7 +1533,14 @@ pub fn start_search_worker(
                             if !file_type.is_file() {
                                 continue;
                             }
-                            if file_contains(&path, &needle, request.case).unwrap_or(false) {
+                            if search_scan::file_contains(
+                                &path,
+                                &needle,
+                                request.case,
+                                &request.cancel,
+                            )
+                            .unwrap_or(false)
+                            {
                                 let size = metadata.as_ref().map(|m| m.len());
                                 let _ = result_tx.send(SearchEvent::Match {
                                     id: request.id,
@@ -1542,57 +1561,6 @@ pub fn start_search_worker(
         }
     });
     (tx, result_rx)
-}
-
-fn file_contains(path: &PathBuf, needle: &str, case: SearchCase) -> std::io::Result<bool> {
-    if needle.is_empty() {
-        return Ok(false);
-    }
-    let mut file = File::open(path)?;
-    let mut buf = vec![0u8; 64 * 1024];
-    let mut carry: Vec<u8> = Vec::new();
-    let needle_bytes = needle.as_bytes();
-    let needle_lower = if case == SearchCase::Insensitive {
-        Some(needle.to_ascii_lowercase().into_bytes())
-    } else {
-        None
-    };
-    loop {
-        let read = file.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-        let mut window = Vec::with_capacity(carry.len() + read);
-        if !carry.is_empty() {
-            window.extend_from_slice(&carry);
-        }
-        window.extend_from_slice(&buf[..read]);
-
-        let found = if let Some(needle_lower) = needle_lower.as_ref() {
-            let mut lowered = window.clone();
-            for byte in &mut lowered {
-                *byte = byte.to_ascii_lowercase();
-            }
-            memchr::memmem::find(&lowered, needle_lower).is_some()
-        } else {
-            memchr::memmem::find(&window, needle_bytes).is_some()
-        };
-        if found {
-            return Ok(true);
-        }
-
-        let keep = needle_bytes.len().saturating_sub(1);
-        if keep > 0 {
-            if window.len() >= keep {
-                carry = window[window.len() - keep..].to_vec();
-            } else {
-                carry = window;
-            }
-        } else {
-            carry.clear();
-        }
-    }
-    Ok(false)
 }
 
 fn wildcard_match(text: &str, pattern: &str) -> bool {
@@ -1751,6 +1719,9 @@ fn run_remote_search(
     let reader = std::io::BufReader::new(&mut channel);
 
     for line_result in reader.lines() {
+        if request.cancel.load(Ordering::Relaxed) {
+            return None;
+        }
         tick = tick.wrapping_add(1);
         if tick.is_multiple_of(32) {
             if let Ok(new_req) = cancel_rx.try_recv() {

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -57,6 +57,8 @@ where
 
 #[path = "search_scan.rs"]
 mod search_scan;
+#[path = "staging.rs"]
+mod staging;
 
 const PREVIEW_CHUNK_BYTES: usize = 16 * 1024;
 
@@ -163,11 +165,10 @@ pub fn start_io_worker(
                     display_name,
                     is_dir,
                 } => {
-                    // Extract into a temp dir, then upload to the remote host.
-                    let tmp_dir = std::env::temp_dir().join("fileman_to_remote");
-                    let extracted = tmp_dir.join(&display_name);
                     let result = (|| -> Result<(), String> {
-                        std::fs::create_dir_all(&tmp_dir).map_err(|e| e.to_string())?;
+                        let staging = staging::TempDir::new().map_err(|e| e.to_string())?;
+                        let extracted = staging.child(&display_name).map_err(|e| e.to_string())?;
+                        let tmp_dir = staging.path().to_path_buf();
                         if is_dir {
                             copy_container_dir(
                                 kind,
@@ -213,12 +214,6 @@ pub fn start_io_worker(
                             )
                         }
                     })();
-                    // Remove the extracted temp copy regardless of outcome.
-                    let _ = if is_dir {
-                        std::fs::remove_dir_all(&extracted)
-                    } else {
-                        std::fs::remove_file(&extracted)
-                    };
                     io_result = match result {
                         Ok(()) => IOResult::CompletedRemote(host),
                         Err(e) => IOResult::ErrorRemote(host, format!("Copy to remote: {e}")),

--- a/tests/copy_safety.rs
+++ b/tests/copy_safety.rs
@@ -1,0 +1,87 @@
+use std::{fs, io, path, sync::atomic};
+
+struct Temp(path::PathBuf);
+
+impl Temp {
+    fn new() -> Self {
+        static NEXT: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+        loop {
+            let id = NEXT.fetch_add(1, atomic::Ordering::Relaxed);
+            let path = std::env::temp_dir()
+                .join(format!("fileman-copy-safety-{}-{id}", std::process::id()));
+            match fs::create_dir(&path) {
+                Ok(()) => return Self(path),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => panic!("create test directory: {error}"),
+            }
+        }
+    }
+}
+
+impl Drop for Temp {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn copying_to_a_hard_link_preserves_both_names() {
+    let dir = Temp::new();
+    let source = dir.0.join("note");
+    let destination = dir.0.join("out");
+    fs::create_dir(&destination).unwrap();
+    fs::write(&source, b"keep these bytes").unwrap();
+    let alias = destination.join("note");
+    fs::hard_link(&source, &alias).unwrap();
+
+    let error = fileman::core::copy_recursively(&source, &destination).unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(fs::read(&source).unwrap(), b"keep these bytes");
+    assert_eq!(fs::read(&alias).unwrap(), b"keep these bytes");
+}
+
+#[test]
+fn ordinary_overwrite_still_works() {
+    let dir = Temp::new();
+    let source = dir.0.join("note");
+    let destination = dir.0.join("out");
+    fs::create_dir(&destination).unwrap();
+    fs::write(&source, b"new bytes").unwrap();
+    fs::write(destination.join("note"), b"old bytes").unwrap();
+
+    fileman::core::copy_recursively(&source, &destination).unwrap();
+    assert_eq!(fs::read(&source).unwrap(), b"new bytes");
+    assert_eq!(fs::read(destination.join("note")).unwrap(), b"new bytes");
+}
+
+#[cfg(unix)]
+#[test]
+fn copying_a_dangling_symlink_still_works() {
+    let dir = Temp::new();
+    let source = dir.0.join("link");
+    let destination = dir.0.join("out");
+    fs::create_dir(&destination).unwrap();
+    std::os::unix::fs::symlink("absent", &source).unwrap();
+
+    fileman::core::copy_recursively(&source, &destination).unwrap();
+    assert_eq!(
+        fs::read_link(destination.join("link")).unwrap(),
+        path::Path::new("absent")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn copying_to_a_symlink_to_a_hard_link_preserves_source() {
+    let dir = Temp::new();
+    let source = dir.0.join("note");
+    let destination = dir.0.join("out");
+    fs::create_dir(&destination).unwrap();
+    fs::write(&source, b"keep these bytes").unwrap();
+    fs::hard_link(&source, dir.0.join("alias")).unwrap();
+    std::os::unix::fs::symlink("../alias", destination.join("note")).unwrap();
+
+    let error = fileman::core::copy_recursively(&source, &destination).unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(fs::read(&source).unwrap(), b"keep these bytes");
+}

--- a/tests/file_mode.rs
+++ b/tests/file_mode.rs
@@ -1,0 +1,7 @@
+#[test]
+fn file_type_bits_do_not_overlap() {
+    assert_eq!(fileman::core::format_mode(0o100644), "-rw-r--r--");
+    assert_eq!(fileman::core::format_mode(0o040755), "drwxr-xr-x");
+    assert_eq!(fileman::core::format_mode(0o120777), "lrwxrwxrwx");
+    assert_eq!(fileman::core::format_mode(0o000644), "-rw-r--r--");
+}

--- a/tests/search_history.rs
+++ b/tests/search_history.rs
@@ -1,0 +1,85 @@
+use fileman::{app_state, core};
+
+fn browser() -> app_state::BrowserState {
+    app_state::BrowserState {
+        browser_mode: core::BrowserMode::Search {
+            root: "/sftp/dev/home/test".into(),
+            query: "notes".into(),
+            mode: core::SearchMode::Name,
+            case: core::SearchCase::Sensitive,
+        },
+        current_path: "/sftp/dev/home/test".into(),
+        selected_index: 0,
+        entries: vec![core::DirEntry {
+            name: "notes.txt".into(),
+            is_dir: false,
+            is_symlink: false,
+            link_target: None,
+            location: core::EntryLocation::Remote {
+                host: "dev".into(),
+                path: "/home/test/notes.txt".into(),
+            },
+            size: Some(12),
+            modified: None,
+        }],
+        load: app_state::LoadState::Idle,
+        progress_override: None,
+        prefer_select_name: None,
+        top_index: 0,
+        container_root: None,
+        dir_token: 0,
+        history_back: Vec::new(),
+        history_forward: Vec::new(),
+        inline_rename: None,
+        sort_mode: core::SortMode::Name,
+        sort_desc: false,
+        watching_archive: None,
+        index_last_seen: 0,
+        marked: Default::default(),
+        parent_cache: Vec::new(),
+    }
+}
+
+#[test]
+fn history_keeps_remote_identity_and_owns_its_results() {
+    let mut browser = browser();
+    let snapshot = app_state::PanelSnapshot::capture(&browser);
+    browser.entries.clear();
+    let entries = snapshot.search_entries.unwrap();
+    assert_eq!(entries.len(), 1);
+    match entries[0].location {
+        core::EntryLocation::Remote { ref host, ref path } => {
+            assert_eq!(host, "dev");
+            assert_eq!(path, "/home/test/notes.txt");
+        }
+        _ => panic!("remote result became local"),
+    }
+    assert_eq!(snapshot.selected_name.as_deref(), Some("notes.txt"));
+}
+
+#[test]
+fn ordinary_history_does_not_copy_a_directory_listing() {
+    let mut browser = browser();
+    browser.browser_mode = core::BrowserMode::Fs;
+    assert!(
+        app_state::PanelSnapshot::capture(&browser)
+            .search_entries
+            .is_none()
+    );
+}
+
+#[test]
+fn a_new_search_tab_keeps_typed_results() {
+    let mut panel = app_state::PanelState {
+        tabs: vec![browser()],
+        active_tab: 0,
+        mode: app_state::PanelMode::Browser,
+    };
+    panel.new_tab();
+    assert_eq!(panel.active_tab, 1);
+    assert_eq!(panel.browser().entries.len(), 1);
+    assert!(matches!(
+        panel.browser().entries[0].location,
+        core::EntryLocation::Remote { .. }
+    ));
+}


### PR DESCRIPTION
Nine focused commits:

- Reject hard-link self-copies, defer GPU view destruction, guard window close, and isolate archive-upload staging.
- Cancel obsolete searches between reads and preserve typed results in history.
- Remove unresolved-preview polling and query free space off the UI thread.
- Correct file-type permission masks.

Validation: formatting, 49 non-network tests, and Clippy with self-update enabled passed in the isolated build. This PR runs the normal platform, SFTP, and replay checks.

Delete/trash behavior is unchanged. Blocking SSH reads and local copy cancellation, full save-and-quit coordination, and the operations tray remain separate work.