### PR TITLE
Add reviewed backtraces and Sentry release symbols

### DIFF
--- a/.github/actions/sentry-symbols/action.yml
+++ b/.github/actions/sentry-symbols/action.yml
@@ -1,0 +1,39 @@
+name: Preserve release symbols
+description: Preserve matching debug files, strip distributables, then upload when configured.
+inputs:
+  binary:
+    description: Exact built executable, before packaging.
+    required: true
+  output:
+    description: Separate directory for this build variant's debug files.
+    required: true
+  bundle-executable:
+    description: Optional already-bundled macOS executable to replace before signing.
+    default: ''
+  auth-token:
+    description: CI-only Sentry token; never compiled into the application.
+    default: ''
+  org:
+    description: Sentry organization slug.
+    default: ''
+  project:
+    description: Sentry project slug.
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Preserve and check debug files
+      shell: bash
+      env:
+        SYMBOL_BINARY: ${{ inputs.binary }}
+        SYMBOL_OUTPUT: ${{ inputs.output }}
+        SYMBOL_BUNDLE: ${{ inputs.bundle-executable }}
+      run: python "$GITHUB_ACTION_PATH/symbols.py" prepare
+    - name: Upload debug files
+      shell: bash
+      env:
+        SYMBOL_OUTPUT: ${{ inputs.output }}
+        SENTRY_AUTH_TOKEN: ${{ inputs.auth-token }}
+        SENTRY_ORG: ${{ inputs.org }}
+        SENTRY_PROJECT: ${{ inputs.project }}
+      run: python "$GITHUB_ACTION_PATH/symbols.py" upload

--- a/.github/actions/sentry-symbols/symbols.py
+++ b/.github/actions/sentry-symbols/symbols.py
@@ -1,0 +1,93 @@
+"""CI symbol handling. The application never invokes this script or Sentry CLI."""
+import hashlib
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+
+VERSION = "3.7.0"
+# Official getsentry/sentry-cli release asset SHA-256 digests, reviewed with this change.
+CLI = {
+    ("Linux", "x86_64"): ("sentry-cli-Linux-x86_64", "cec71d46a7cc394c94b6e75f1601985c710d457376c546ef3975567b3671563b"),
+    ("Darwin", "arm64"): ("sentry-cli-Darwin-arm64", "c66564094fbe56ee3b359f7574541f858b8d1df0328a0a759da972fbf1886048"),
+    ("Darwin", "x86_64"): ("sentry-cli-Darwin-x86_64", "fcd74786b4d95c6b7531662607897aadd5ab5d64c5d0468a6f4bd97ad04bedb8"),
+    ("Windows", "AMD64"): ("sentry-cli-Windows-x86_64.exe", "8643986aec8d8cf8d69cd476d67427578e5dbbda378eba506d199681082abe5a"),
+}
+
+
+def cli():
+    name, digest = CLI[(platform.system(), platform.machine())]
+    target = Path(os.environ["RUNNER_TEMP"]) / name
+    if not target.exists():
+        url = f"https://github.com/getsentry/sentry-cli/releases/download/{VERSION}/{name}"
+        with urllib.request.urlopen(url, timeout=60) as response:
+            content = response.read(40 * 1024 * 1024)
+        if hashlib.sha256(content).hexdigest() != digest:
+            raise RuntimeError("Sentry CLI checksum mismatch")
+        target.write_bytes(content)
+        target.chmod(0o700)
+    if hashlib.sha256(target.read_bytes()).hexdigest() != digest:
+        raise RuntimeError("Sentry CLI checksum mismatch")
+    return str(target)
+
+
+def prepare():
+    binary = Path(os.environ["SYMBOL_BINARY"])
+    output = Path(os.environ["SYMBOL_OUTPUT"])
+    output.mkdir(parents=True, exist_ok=False)
+    if not binary.is_file():
+        raise RuntimeError("Missing built executable")
+    system = platform.system()
+    if system == "Linux":
+        debug = output / (binary.name + ".debug")
+        subprocess.run(["objcopy", "--only-keep-debug", str(binary), str(debug)], check=True)
+        subprocess.run(["objcopy", "--strip-debug", "--strip-unneeded", str(binary)], check=True)
+        subprocess.run(["objcopy", "--add-gnu-debuglink=" + str(debug.resolve()), str(binary)], check=True)
+    elif system == "Darwin":
+        dsym = Path(str(binary) + ".dSYM")
+        if not dsym.is_dir():
+            subprocess.run(["dsymutil", str(binary), "-o", str(dsym)], check=True)
+        shutil.copytree(dsym, output / dsym.name)
+        subprocess.run(["strip", "-S", str(binary)], check=True)
+        bundled = os.environ.get("SYMBOL_BUNDLE", "")
+        if bundled:
+            if not Path(bundled).is_file():
+                raise RuntimeError("Missing bundled executable")
+            shutil.copy2(binary, bundled)
+    elif system == "Windows":
+        pdb = binary.with_suffix(".pdb")
+        if not pdb.is_file():
+            raise RuntimeError("Missing PDB; compile with release debug information")
+        shutil.copy2(pdb, output / pdb.name)
+    else:
+        raise RuntimeError("Unsupported symbol platform")
+    # Keep the stripped executable as well: its ID must match its debug companion.
+    shutil.copy2(binary, output / binary.name)
+
+
+def upload():
+    values = [os.environ.get(name, "") for name in ("SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT")]
+    if not any(values):
+        print("Sentry upload disabled: no configuration (debug files retained locally).")
+        return
+    if not all(values) or any(not re.fullmatch(r"[a-zA-Z0-9_-]+", v) for v in values[1:]):
+        raise RuntimeError("Incomplete Sentry symbol configuration")
+    executable = cli()
+    # No recursive checkout upload and no source bundles; only this variant's output.
+    subprocess.run([executable, "debug-files", "upload", "--wait", os.environ["SYMBOL_OUTPUT"]],
+                   check=True, timeout=300)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in {"prepare", "upload", "install"}:
+        raise SystemExit("Expected prepare, upload, or install")
+    if sys.argv[1] == "install":
+        print(cli())
+    elif sys.argv[1] == "prepare":
+        prepare()
+    else:
+        upload()

--- a/.github/workflows/crash-validation.yml
+++ b/.github/workflows/crash-validation.yml
@@ -1,0 +1,78 @@
+name: Crash diagnostics
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  capture:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    env:
+      CC: navigato-no-c-compiler
+      CXX: navigato-no-cxx-compiler
+      CARGO_PROFILE_DIAGNOSTICS_SPLIT_DEBUGINFO: ${{ matrix.os == 'ubuntu-latest' && 'off' || 'packed' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Test support and import boundaries
+        shell: bash
+        run: |
+          cargo test --locked -p navigato-support
+          cargo clippy --locked -p navigato-support --all-targets -- -D warnings
+          python -m unittest discover -s scripts -p test_sentry_report.py
+      - name: Build optimized probe
+        run: cargo build --locked -p navigato-support --example crash_probe --profile diagnostics
+      - name: Separate symbols and strip executable
+        uses: ./.github/actions/sentry-symbols
+        with:
+          binary: target/diagnostics/examples/crash_probe${{ runner.os == 'Windows' && '.exe' || '' }}
+          output: ${{ runner.temp }}/probe-symbols
+      - name: Validate stripped probe
+        shell: bash
+        run: |
+          python scripts/validate_crash.py \
+            "target/diagnostics/examples/crash_probe${{ runner.os == 'Windows' && '.exe' || '' }}" \
+            "$RUNNER_TEMP/probe-symbols" "$RUNNER_TEMP/probe-report"
+      # Dispatch only after merge. PRs never receive these credentials or send events.
+      - name: Upload synthetic probe symbols
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG || vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT || vars.SENTRY_PROJECT }}
+          SYMBOL_OUTPUT: ${{ runner.temp }}/probe-symbols
+        run: |
+          test -n "$SENTRY_AUTH_TOKEN" && test -n "$SENTRY_ORG" && test -n "$SENTRY_PROJECT"
+          python .github/actions/sentry-symbols/symbols.py upload
+      - name: Send this synthetic report only
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN || vars.SENTRY_DSN }}
+        run: |
+          python - <<'PY'
+          import json, os, pathlib, sys
+          sys.path.insert(0, "scripts")
+          import sentry_report
+          paths = list(pathlib.Path(os.environ["RUNNER_TEMP"], "probe-report").glob("failure-*.json"))
+          assert len(paths) == 1
+          report = json.loads(paths[0].read_text())
+          assert report["version"] == "0.0.0-sentry-probe"
+          report["sentry_consent"] = True  # This workflow owns the synthetic data.
+          event_id = sentry_report.send_report(report, "fileman", os.environ["SENTRY_DSN"])
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+              summary.write(f"Synthetic Sentry event accepted: `{event_id}`. Verify readable `synthetic_panic` frames in Sentry; acceptance alone is not symbolication.\n")
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
             rustflags: ""
             suffix: ""
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_PROFILE_RELEASE_DEBUG: "1"
+      CARGO_PROFILE_RELEASE_STRIP: "false"
+      CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: ${{ matrix.os == 'ubuntu-latest' && 'off' || 'packed' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -45,11 +49,31 @@ jobs:
           cargo install cargo-bundle --git https://github.com/burtonageo/cargo-bundle --rev 17cc8eb --locked
           cargo install cargo-deb cargo-generate-rpm
 
-      - name: Build + bundle with self-update (Linux)
+      - name: Build (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: cargo bundle --release --features self-update
+        run: cargo build --release --locked --bin fileman --features self-update
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+
+      - name: Preserve Linux symbols
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./.github/actions/sentry-symbols
+        with:
+          binary: target/release/fileman
+          output: target/symbols/portable
+          auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          org: ${{ secrets.SENTRY_ORG || vars.SENTRY_ORG }}
+          project: ${{ secrets.SENTRY_PROJECT || vars.SENTRY_PROJECT }}
+
+      - name: Bundle (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo bundle --release --bin fileman --features self-update
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+
+      - name: Verify bundled executable (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: cmp target/release/fileman target/symbols/portable/fileman
 
       - name: Package tarball (Linux)
         if: matrix.os == 'ubuntu-latest'
@@ -66,6 +90,16 @@ jobs:
       - name: Rebuild without self-update for packages (Linux Vulkan)
         if: matrix.os == 'ubuntu-latest' && matrix.variant == 'vulkan'
         run: cargo build --release --bin fileman
+
+      - name: Preserve package symbols
+        if: matrix.os == 'ubuntu-latest' && matrix.variant == 'vulkan'
+        uses: ./.github/actions/sentry-symbols
+        with:
+          binary: target/release/fileman
+          output: target/symbols/packages
+          auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          org: ${{ secrets.SENTRY_ORG || vars.SENTRY_ORG }}
+          project: ${{ secrets.SENTRY_PROJECT || vars.SENTRY_PROJECT }}
 
       - name: Package deb + rpm (Linux Vulkan)
         if: matrix.os == 'ubuntu-latest' && matrix.variant == 'vulkan'
@@ -86,6 +120,17 @@ jobs:
       # Signs with Developer ID, notarizes, and staples when the secrets below
       # are configured; falls back to an ad-hoc signature otherwise so the job
       # still produces artifacts on forks. See CONTRIBUTING.md for the setup.
+      - name: Preserve macOS symbols
+        if: matrix.os == 'macos-latest'
+        uses: ./.github/actions/sentry-symbols
+        with:
+          binary: target/aarch64-apple-darwin/release/fileman
+          output: target/symbols/macos
+          bundle-executable: target/aarch64-apple-darwin/release/bundle/osx/FileMan.app/Contents/MacOS/fileman
+          auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          org: ${{ secrets.SENTRY_ORG || vars.SENTRY_ORG }}
+          project: ${{ secrets.SENTRY_PROJECT || vars.SENTRY_PROJECT }}
+
       - name: Package (macOS)
         if: matrix.os == 'macos-latest'
         run: scripts/macos_package.sh
@@ -102,6 +147,16 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: cargo build --release --bin fileman --features self-update
+
+      - name: Preserve Windows symbols
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/sentry-symbols
+        with:
+          binary: target/release/fileman.exe
+          output: target/symbols/windows
+          auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          org: ${{ secrets.SENTRY_ORG || vars.SENTRY_ORG }}
+          project: ${{ secrets.SENTRY_PROJECT || vars.SENTRY_PROJECT }}
 
       - name: Package zip (Windows)
         if: matrix.os == 'windows-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +265,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base16ct"
@@ -963,6 +987,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +1005,12 @@ dependencies = [
  "const-oid",
  "zeroize",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "des"
@@ -1394,6 +1434,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1758,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"
@@ -2153,6 +2217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,7 +2439,10 @@ dependencies = [
 name = "navigato-support"
 version = "0.1.0"
 dependencies = [
+ "backtrace",
  "egui",
+ "sentry-core",
+ "sentry-debug-images",
  "serde",
  "serde_json",
 ]
@@ -2409,6 +2482,12 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2762,6 +2841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,6 +3084,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,9 +3262,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3416,6 +3510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,6 +3668,45 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "sentry-core"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d889520a375e5b93efb0a66def1630d21d168b0251eb55b286b03fa940ccfc84"
+dependencies = [
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656487fd5f7b7c0105b2e82171982aac64489e0cb679436038febf070f2f76d6"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc71f5ca55942d9b2901af95d5df5c5d65c164134c22a83682cac3d0b6c7ef2d"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -4117,6 +4256,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4421,6 +4590,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4450,6 +4620,11 @@ name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vello_common"
@@ -4769,6 +4944,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4776,6 +4967,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(gles)'] }
 members = ["support"]
 default-members = [".", "support"]
 resolver = "2"
+
+[profile.diagnostics]
+inherits = "release"
+debug = 1
+strip = false

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -27,9 +27,28 @@ such as `src/main.rs`, never runtime file paths. Local report filenames contain 
 time and process number for collision avoidance; those names are not exported.
 
 Rust panic recording is best effort and includes caught/worker panics, not just
-process crashes. It does not collect native crashes, stack traces, minidumps or
-unclean-exit guesses. Fatal renderer/desktop failures use stable classifications.
+process crashes. It does not collect native crashes, minidumps or unclean-exit guesses. Fatal renderer/desktop failures use stable classifications.
 The ordinary local panic/error logger is unchanged; it is never attached.
+
+## Optional backtraces and Sentry
+
+**Include application backtraces locally** is independently off by default, including
+when upgrading older preferences. When enabled, failure reports add at most 48
+executable-relative code offsets, its debug/build ID, image size and preferred load
+address. They do not include actual ASLR load addresses, loaded-library names,
+resolved compiler paths, thread names, variables, memory or panic payloads. Missing
+executable metadata leaves a category-only report. Turning this option off clears
+saved failure reports. Reports remain bounded to 8 KiB and are never sent by the app.
+
+The report review has a separate, unchecked **Allow the maintainer to import this
+report into private Sentry diagnostics** choice. That applies only to the copied or
+emailed report. Private email alone does not grant this permission. The maintainer
+importer refuses delivery without it and refuses usage reports. It sends one
+validated event to the separately configured hosted Sentry project, with no retries,
+redirects, source attachments or raw logs. Sentry sees the importer's network IP,
+not an end-user IP recorded by the app. Project access and retention are controlled
+by the maintainer's Sentry account; that account's policies also apply to imported
+reports. The app's seven-day local expiry does not delete reports already imported.
 
 ## Optional statistics
 
@@ -76,12 +95,22 @@ compiling. An absent or invalid address disables the private-report link, never
 falls back to an author's public email. Changing the alias requires a rebuild.
 `GITHUB_SHA`, when supplied by CI, identifies the exact build.
 
+## Symbol uploads
+
+Official release workflows preserve line-level debug information for each build
+variant and upload it when `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` and `SENTRY_PROJECT` are
+configured. Org/project values may be GitHub secrets or variables. Only release
+symbols and the corresponding executable are uploaded, never a checkout-wide scan
+or source bundle. The auth token is CI-only and is not embedded into the app.
+`SENTRY_DSN` is used only by the explicit synthetic smoke workflow or a maintainer
+import; it is not an application upload switch. See `SENTRY.md` for validation.
+
 ## Next delivery milestone
 
-Hosted diagnostics and product analytics are **not enabled**. The current Sentry
+Automatic application uploads and product analytics delivery are **not enabled**. The current Sentry
 transport/dependency proof does not satisfy Starcom's no-native-crypto policy.
 Do not remove that policy or substitute an experimental TLS implementation merely
 for telemetry. Before adding uploads: select and validate a compliant transport,
-provision the private backend, document retention/IP handling, add distinct upload
+confirm the private backend and its retention/IP settings, add distinct automatic-upload
 consent, enforce bounded delivery/retries, and verify symbolized packaged-release
 reports. Local collection consent does not authorize a future automatic uploader.

--- a/SENTRY.md
+++ b/SENTRY.md
@@ -1,0 +1,75 @@
+# Crash diagnostics
+
+Sentry account setup alone does not capture or deliver application crashes.
+This increment provides optional local backtraces, reviewed maintainer import,
+and debug-file uploads. It adds no HTTP/TLS client to Fileman or Starcom.
+
+## Configuration
+
+`SENTRY_AUTH_TOKEN` stays in Actions secrets. `SENTRY_ORG` and `SENTRY_PROJECT`
+may be secrets or variables; secrets take precedence. Scope project/DSN values
+per repository when the apps use separate Sentry projects. Releases skip Sentry
+only when all three symbol settings are absent; incomplete configuration fails.
+`SENTRY_DSN` is a project ingestion destination, not a read/admin credential.
+Never embed the auth token or pass it to application builds.
+
+No automatic tracing, logs, profiling, session recording or usage upload is enabled.
+Keep project access private and configure retention/IP handling in Sentry before
+importing user reports. Clearing local reports does not retract prior imports.
+
+## Validate after merging
+
+Run **Crash diagnostics** manually on Fileman's `main`. Normal PR/main runs perform
+only local checks. The manual main-branch run additionally uploads each platform's
+probe symbols and sends one synthetic event using the configured credentials.
+The step summary records event IDs. Open each event in Sentry and confirm
+`crash_probe::synthetic_panic` resolves to `crash_probe.rs` with a line number.
+A 2xx ingestion response alone is not proof of symbolication.
+
+Linux checks source-line resolution against the extracted debug file; macOS checks
+the dSYM locally. Windows validates address capture and the presence of the PDB;
+server-side PDB symbolication remains part of the manual Sentry acceptance test.
+These are optimized/stripped probe binaries, not a claim that packaged application
+crashes on every OS have already been exercised.
+
+## User reports
+
+In Help/About, enable **Include application backtraces locally** before reproducing
+a failure. Review the report and explicitly authorize Sentry processing before
+copying/emailing it. Default or older category-only reports contain no backtrace.
+
+For a report whose sender authorized Sentry processing, on the maintainer's machine:
+
+```sh
+# Validate and inspect the exact reconstructed event; no network access.
+python3 scripts/sentry_report.py report.json --app fileman
+# Send once to the destination in SENTRY_DSN, after review.
+python3 scripts/sentry_report.py report.json --app fileman --send
+```
+
+Use `--app starcom` for Starcom. The importer rejects unknown/content fields, usage
+reports, missing permission, wrong app, oversized input and non-Sentry destinations.
+There are no automatic retries: uncertain delivery must not quietly duplicate a
+report. Private reports must never be pasted into public Actions inputs/artifacts
+or the organization issue-triage workflow. Do not attach raw logs or memory dumps.
+
+## Release symbols
+
+The release workflow overrides Cargo's debug/strip settings only for official
+builds; ordinary `cargo install --release` retains its previous size defaults.
+Linux extracts `.debug` before stripping and packaging. macOS retains a dSYM and
+strips/copies the executable into its bundle before signing. Windows retains the
+PDB. Each Fileman feature/backend variant is handled before a later build can
+replace its executable. Matching is by binary debug ID, not just the Git SHA.
+
+The shared action uploads only its dedicated symbol directory, waits for debug-file
+processing, and fails the release on a configured upload failure. It uses a
+hash-checked Sentry CLI 3.7.0. No paid live upload is performed by a PR check.
+
+## Remaining coverage
+
+Rust panic capture is best effort and includes caught/worker panics. Fatal-error
+stacks show the reporting call path, not a recovered GPU-driver crash. Native
+signals, access violations, process aborts and OOM kills are not captured. A
+compatible, reviewed application HTTPS transport and a separate automatic-upload
+consent contract are still required before in-app delivery can be enabled.

--- a/scripts/sentry_report.py
+++ b/scripts/sentry_report.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Validate a reviewed Navigato report and optionally import it into hosted Sentry.
+
+No network access without --send. Run locally for private reports, never in public CI.
+Only the environment supplies the destination; a report cannot choose its recipient.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+MAX_BYTES = 8192
+KINDS = {"panic", "gpu_initialization", "surface_creation", "frame_wait", "desktop_exit"}
+TOKEN = r"[a-zA-Z0-9._+\-]{1,80}"
+HEX_ID = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?:-[0-9a-fA-F]{1,8})?"
+
+
+def require(condition):
+    if not condition:
+        raise ValueError("Invalid or unsupported diagnostic report")
+
+
+def fields(value, required, optional=()):
+    require(type(value) is dict and set(required) <= value.keys()
+            and value.keys() <= set(required) | set(optional))
+
+
+def text(value, pattern):
+    return type(value) is str and re.fullmatch(pattern, value) is not None
+
+
+def integer(value, low, high):
+    return type(value) is int and low <= value <= high
+
+
+def event_from_report(report, app):
+    fields(report, {"schema", "app", "version", "revision", "os", "arch", "payload"}, {"sentry_consent"})
+    require(type(report.get("sentry_consent", False)) is bool)
+    require(type(report["schema"]) is int and report["schema"] == 2)
+    require(report["app"] == app and app in {"fileman", "starcom"})
+    require(text(report["version"], TOKEN) and text(report["revision"], TOKEN))
+    require(report["os"] in {"linux", "macos", "windows"})
+    require(report["arch"] in {"x86", "x86_64", "arm", "aarch64", "riscv64"})
+    payload = report["payload"]
+    fields(payload, {"type", "kind", "site", "trace"})
+    require(payload["type"] == "failure" and payload["kind"] in KINDS)
+    site = payload["site"]
+    if site is not None:
+        fields(site, {"file", "line", "column"})
+        require(text(site["file"], r"src/[a-zA-Z0-9/_\-.]{1,153}\.rs")
+                and ".." not in site["file"])
+        require(integer(site["line"], 0, 2**32 - 1) and integer(site["column"], 0, 2**32 - 1))
+    trace = payload["trace"]
+    fields(trace, {"debug_id", "code_id", "image_size", "image_vmaddr", "offsets"})
+    require(text(trace["debug_id"], HEX_ID))
+    require(trace["code_id"] is None or text(trace["code_id"], r"[0-9a-fA-F]{1,128}"))
+    require(integer(trace["image_size"], 1, 2**40))
+    require(integer(trace["image_vmaddr"], 0, 2**64 - 1))
+    offsets = trace["offsets"]
+    require(type(offsets) is list and 0 < len(offsets) <= 48)
+    require(all(integer(offset, 0, trace["image_size"] - 1) for offset in offsets))
+    # Reconstruct a closed event rather than forwarding fields from untrusted JSON.
+    image = {
+        "type": {"linux": "elf", "macos": "macho", "windows": "pe"}[report["os"]],
+        "debug_id": trace["debug_id"], "code_file": app,
+        "image_addr": "0x0", "image_size": trace["image_size"],
+        "image_vmaddr": hex(trace["image_vmaddr"]), "arch": report["arch"],
+    }
+    if trace["code_id"] is not None:
+        image["code_id"] = trace["code_id"]
+    if report["os"] == "windows":
+        image["debug_file"] = app + ".pdb"
+    return {
+        "event_id": uuid.uuid4().hex, "platform": "native", "level": "error",
+        "release": f"{app}@{report['version']}+{report['revision']}",
+        "environment": "reviewed-report",
+        "exception": {"values": [{
+            "type": payload["kind"], "value": "User-reviewed application failure",
+            # These are sampled return addresses, not a faulting CPU context.
+            "stacktrace": {"instruction_addr_adjustment": "all", "frames": [
+                {"instruction_addr": hex(offset), "addr_mode": "rel:0", "in_app": True}
+                for offset in offsets
+            ]},
+        }]},
+        "debug_meta": {"images": [image]},
+        "tags": {"app": app, "os": report["os"], "arch": report["arch"],
+                 "capture_time": "unknown", "capture": "executable-only"},
+    }
+
+
+def destination(dsn):
+    try:
+        url = urllib.parse.urlsplit(dsn)
+        require(url.scheme == "https" and url.port in (None, 443)
+                and url.password is None and not url.query and not url.fragment)
+        require(text(url.username, r"[a-fA-F0-9]{32,64}")
+                and text(url.hostname, r"o[0-9]+\.ingest\.(?:[a-z]{2}\.)?sentry\.io")
+                and text(url.path, r"/[0-9]+"))
+        return f"https://{url.hostname}/api{url.path}/envelope/", url.username
+    except (ValueError, TypeError):
+        raise ValueError("SENTRY_DSN must identify a hosted HTTPS Sentry project") from None
+
+
+class NoRedirects(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise ValueError("Sentry redirect refused; no report was forwarded")
+
+
+def send_report(report, app, dsn):
+    require(report.get("sentry_consent") is True)
+    event = event_from_report(report, app)
+    return _send_event(event, dsn)
+
+
+def _send_event(event, dsn):
+    url, key = destination(dsn)
+    encoded = json.dumps(event, separators=(",", ":")).encode()
+    envelope = (json.dumps({"event_id": event["event_id"]}).encode() + b"\n"
+                + json.dumps({"type": "event", "length": len(encoded)}).encode()
+                + b"\n" + encoded + b"\n")
+    request = urllib.request.Request(url, envelope, headers={
+        "Content-Type": "application/x-sentry-envelope",
+        "X-Sentry-Auth": f"Sentry sentry_version=7, sentry_key={key}, sentry_client=navigato-import/1",
+    })
+    # Use Python's verified HTTPS transport only in this maintainer tool, not the app.
+    # No proxy discovery, redirects, authentication token, retries, or attachments.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), NoRedirects())
+    try:
+        with opener.open(request, timeout=15) as response:
+            require(200 <= response.status < 300)
+            response.read(MAX_BYTES)
+    except urllib.error.HTTPError as error:
+        raise ValueError(f"Sentry rejected the report (HTTP {error.code}); not retried") from None
+    except (OSError, urllib.error.URLError):
+        raise ValueError("Sentry delivery failed; outcome may be uncertain, not retried") from None
+    return event["event_id"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--app", choices=["fileman", "starcom"], required=True)
+    parser.add_argument("--send", action="store_true", help="send this reviewed report to SENTRY_DSN")
+    args = parser.parse_args()
+    with args.report.open("rb") as file:
+        data = file.read(MAX_BYTES + 1)
+    require(len(data) <= MAX_BYTES)
+    report = json.loads(data)
+    if args.send:
+        event_id = send_report(report, args.app, os.environ.get("SENTRY_DSN", ""))
+        print(f"Sentry accepted event {event_id}; inspect symbolication in the project.")
+    else:
+        print(json.dumps(event_from_report(report, args.app), indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, TypeError, KeyError, RecursionError, OSError):
+        # Exception text may contain input or an endpoint. Do not dump it in CI.
+        print("Report validation or delivery failed; no automatic retry.", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/test_sentry_report.py
+++ b/scripts/test_sentry_report.py
@@ -1,0 +1,125 @@
+import json
+import unittest
+from unittest import mock
+
+import sentry_report as sentry
+
+
+def report():
+    return {"schema": 2, "app": "fileman", "version": "0.4.0", "revision": "abcdef",
+            "os": "linux", "arch": "x86_64", "payload": {
+                "type": "failure", "kind": "panic", "site": None, "trace": {
+                    "debug_id": "12345678-abcd-0000-0000-0123456789ab", "code_id": "abcd",
+                    "image_size": 65536, "image_vmaddr": 0, "offsets": [2048, 1024]}}}
+
+
+class ReportTests(unittest.TestCase):
+    def test_relative_frames_and_binary_identity_are_preserved(self):
+        event = sentry.event_from_report(report(), "fileman")
+        stack = event["exception"]["values"][0]["stacktrace"]
+        self.assertEqual(stack["instruction_addr_adjustment"], "all")
+        frames = stack["frames"]
+        self.assertEqual(frames[0]["instruction_addr"], "0x800")
+        self.assertEqual(frames[1]["addr_mode"], "rel:0")
+        self.assertEqual(event["debug_meta"]["images"][0]["debug_id"], report()["payload"]["trace"]["debug_id"])
+        self.assertNotIn("user", event)
+        self.assertNotIn("timestamp", event)
+
+    def test_unknown_fields_at_every_level_are_rejected(self):
+        for location in [(), ("payload",), ("payload", "trace")]:
+            value = report()
+            node = value
+            for key in location:
+                node = node[key]
+            node["CANARY"] = "/secret/host"
+            with self.assertRaises(ValueError):
+                sentry.event_from_report(value, "fileman")
+
+    def test_bad_values_wrong_apps_and_usage_are_rejected(self):
+        for key, value in [("schema", True), ("schema", 1), ("app", "starcom"),
+                           ("version", "/home/CANARY"), ("revision", "x\n"), ("os", "private-os")]:
+            sample = report()
+            sample[key] = value
+            with self.assertRaises(ValueError):
+                sentry.event_from_report(sample, "fileman")
+        sample = report()
+        sample["payload"] = {"type": "usage", "counters": {}}
+        with self.assertRaises(ValueError):
+            sentry.event_from_report(sample, "fileman")
+
+    def test_offsets_are_bounded_and_not_booleans(self):
+        for offsets in [[], [True], [-1], [65536], [0] * 49, "CANARY"]:
+            sample = report()
+            sample["payload"]["trace"]["offsets"] = offsets
+            with self.assertRaises(ValueError):
+                sentry.event_from_report(sample, "fileman")
+
+    def test_source_and_image_fields_cannot_contain_runtime_paths(self):
+        for location in ["/home/CANARY/src/main.rs", "src/../CANARY.rs"]:
+            sample = report()
+            sample["payload"]["site"] = {"file": location, "line": 1, "column": 1}
+            with self.assertRaises(ValueError):
+                sentry.event_from_report(sample, "fileman")
+        for field in ["debug_id", "code_id"]:
+            sample = report()
+            sample["payload"]["trace"][field] = "/home/CANARY"
+            with self.assertRaises(ValueError):
+                sentry.event_from_report(sample, "fileman")
+
+    def test_only_hosted_https_ingestion_is_accepted(self):
+        key = "a" * 32
+        for host in ["o1.ingest.sentry.io", "o1.ingest.us.sentry.io", "o1.ingest.de.sentry.io"]:
+            endpoint, public = sentry.destination(f"https://{key}@{host}/12")
+            self.assertEqual(endpoint, f"https://{host}/api/12/envelope/")
+            self.assertEqual(public, key)
+        for dsn in [f"http://{key}@o1.ingest.sentry.io/1", f"https://{key}@localhost/1",
+                    f"https://{key}@o1.ingest.sentry.io.evil.test/1",
+                    f"https://{key}@o1.ingest.sentry.io:123/1",
+                    f"https://{key}:CANARY@o1.ingest.sentry.io/1",
+                    f"https://{key}@o1.ingest.sentry.io/1?recipient=evil"]:
+            with self.assertRaises(ValueError):
+                sentry.destination(dsn)
+
+    def test_conversion_does_no_network_io(self):
+        with mock.patch.object(sentry.urllib.request, "build_opener") as opener:
+            sentry.event_from_report(report(), "fileman")
+            opener.assert_not_called()
+
+    def test_invalid_dsn_does_no_network_io(self):
+        with mock.patch.object(sentry.urllib.request, "build_opener") as opener:
+            with self.assertRaises(ValueError):
+                sentry._send_event(sentry.event_from_report(report(), "fileman"), "")
+            opener.assert_not_called()
+
+    def test_private_email_does_not_authorize_third_party_upload(self):
+        for consent in [None, False, 1, "true"]:
+            sample = report()
+            if consent is not None:
+                sample["sentry_consent"] = consent
+            with mock.patch.object(sentry.urllib.request, "build_opener") as opener:
+                with self.assertRaises(ValueError):
+                    sentry.send_report(sample, "fileman", f"https://{'a'*32}@o1.ingest.sentry.io/1")
+                opener.assert_not_called()
+
+    def test_redirects_never_forward_the_event(self):
+        with self.assertRaises(ValueError):
+            sentry.NoRedirects().redirect_request(None, None, 307, "", {}, "https://evil.test")
+
+    def test_sends_one_valid_envelope_and_no_auth_token(self):
+        event = sentry.event_from_report(report(), "fileman")
+        with mock.patch.object(sentry.urllib.request, "build_opener") as builder:
+            response = builder.return_value.open.return_value.__enter__.return_value
+            response.status = 200
+            returned = sentry._send_event(event, f"https://{'a'*32}@o1.ingest.sentry.io/1")
+            self.assertEqual(returned, event["event_id"])
+            args, kwargs = builder.return_value.open.call_args
+            header, item, body = args[0].data.splitlines()
+            self.assertEqual(json.loads(item)["length"], len(body))
+            self.assertEqual(json.loads(header)["event_id"], event["event_id"])
+            self.assertEqual(kwargs["timeout"], 15)
+            self.assertNotIn("Bearer", str(args[0].headers))
+            builder.return_value.open.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_crash.py
+++ b/scripts/validate_crash.py
@@ -1,0 +1,45 @@
+"""Run only the isolated synthetic probe, never a real application's profile."""
+import argparse
+import json
+from pathlib import Path
+import platform
+import re
+import subprocess
+
+import sentry_report
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("binary", type=Path)
+parser.add_argument("symbols", type=Path)
+parser.add_argument("destination", type=Path)
+args = parser.parse_args()
+result = subprocess.run([str(args.binary.resolve()), str(args.destination)],
+                        capture_output=True, timeout=30)
+assert result.returncode != 0, "probe did not panic"
+reports = list(args.destination.glob("failure-*.json"))
+assert len(reports) == 1, "expected one isolated diagnostic report"
+text = reports[0].read_text()
+assert "CANARY" not in text, "panic payload leaked into the report"
+report = json.loads(text)
+assert report["sentry_consent"] is False
+trace = report["payload"]["trace"]
+assert trace and trace["offsets"], "executable backtrace was not captured"
+sentry_report.event_from_report(report, "fileman")
+# Match Sentry's return-address adjustment when checking locally. AArch64
+# instructions are four bytes; x86 needs only to point inside the call instruction.
+adjustment = {"aarch64": 4, "arm": 2, "riscv64": 2}.get(report["arch"], 1)
+addresses = [hex(max(0, offset - adjustment) + trace["image_vmaddr"]) for offset in trace["offsets"]]
+if platform.system() == "Linux":
+    debug = args.symbols / (args.binary.name + ".debug")
+    resolved = subprocess.check_output(["addr2line", "-f", "-C", "-e", str(debug), *addresses], text=True)
+    lines = resolved.splitlines()
+    assert any("synthetic_panic" in function and re.search(r"crash_probe\.rs:[1-9][0-9]*", site)
+               for function, site in zip(lines[::2], lines[1::2])), "panic frame has no source line"
+elif platform.system() == "Darwin":
+    dwarf = args.symbols / (args.binary.name + ".dSYM") / "Contents/Resources/DWARF" / args.binary.name
+    resolved = subprocess.check_output(["atos", "-o", str(dwarf), *addresses], text=True)
+    assert any("synthetic_panic" in line and re.search(r"crash_probe\.rs:[1-9][0-9]*", line)
+               for line in resolved.splitlines()), "panic frame has no source line"
+else:
+    assert (args.symbols / args.binary.with_suffix(".pdb").name).stat().st_size > 0
+print(f"Synthetic panic: {len(trace['offsets'])} executable frames; report validation passed.")

--- a/scripts/validate_crash.py
+++ b/scripts/validate_crash.py
@@ -36,7 +36,10 @@ if platform.system() == "Linux":
     assert any("synthetic_panic" in function and re.search(r"crash_probe\.rs:[1-9][0-9]*", site)
                for function, site in zip(lines[::2], lines[1::2])), "panic frame has no source line"
 elif platform.system() == "Darwin":
-    dwarf = args.symbols / (args.binary.name + ".dSYM") / "Contents/Resources/DWARF" / args.binary.name
+    # Cargo may keep the hashed example filename inside the renamed dSYM.
+    dwarfs = list((args.symbols / (args.binary.name + ".dSYM") / "Contents/Resources/DWARF").iterdir())
+    assert len(dwarfs) == 1 and dwarfs[0].is_file(), "expected one probe DWARF file"
+    dwarf = dwarfs[0]
     resolved = subprocess.check_output(["atos", "-o", str(dwarf), *addresses], text=True)
     assert any("synthetic_panic" in line and re.search(r"crash_probe\.rs:[1-9][0-9]*", line)
                for line in resolved.splitlines()), "panic frame has no source line"

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -8,6 +8,9 @@ description = "Content-free, local diagnostics and feedback for Navigato applica
 repository = "https://github.com/navigato-rs/fileman"
 
 [dependencies]
+backtrace = "0.3.76"
+sentry-core = { version = "=0.49.2", default-features = false }
+sentry-debug-images = "=0.49.2"
 egui = { version = "0.34", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/support/README.md
+++ b/support/README.md
@@ -12,3 +12,9 @@ the controls in an existing egui surface. See [the privacy contract](../PRIVACY.
 allowlisting, bounds, permissions, symlinks, locking, panic payload exclusion and
 consent changes. `cargo clippy -p navigato-support --all-targets -- -D warnings`
 checks the package without enabling any telemetry transport.
+
+Optional backtraces are separately consented, bounded executable-relative offsets.
+The Sentry crates are used for image metadata only: no SDK client/transport is
+initialized. `scripts/sentry_report.py` is a maintainer-only import tool, not an
+application dependency. Private-email consent does not authorize Sentry import.
+See `SENTRY.md` and `PRIVACY.md` at the repository root.

--- a/support/examples/crash_probe.rs
+++ b/support/examples/crash_probe.rs
@@ -8,7 +8,7 @@ fn synthetic_panic() {
 
 fn main() -> std::io::Result<()> {
     let root = path::PathBuf::from(std::env::args_os().nth(1).expect("new report directory"));
-    let mut builder = fs::DirBuilder::new();
+    let builder = &mut fs::DirBuilder::new();
     #[cfg(unix)]
     {
         use std::os::unix::fs::DirBuilderExt as _;

--- a/support/examples/crash_probe.rs
+++ b/support/examples/crash_probe.rs
@@ -1,0 +1,39 @@
+//! Isolated synthetic panic for symbol validation; never reads real app state.
+use std::{fs, io::Write as _, path};
+
+#[inline(never)]
+fn synthetic_panic() {
+    panic!("NAVIGATO_TEST_CANARY: not reportable content");
+}
+
+fn main() -> std::io::Result<()> {
+    let root = path::PathBuf::from(std::env::args_os().nth(1).expect("new report directory"));
+    let mut builder = fs::DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        builder.mode(0o700);
+    }
+    builder.create(&root)?;
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    options
+        .open(root.join("preferences.json"))?
+        .write_all(br#"{"diagnostics":true,"backtraces":true,"usage":false}"#)?;
+    let _session = navigato_support::init(
+        navigato_support::Info {
+            app: navigato_support::App::Fileman,
+            version: "0.0.0-sentry-probe",
+            revision: option_env!("GITHUB_SHA"),
+            private_email: None,
+        },
+        Some(root),
+    );
+    synthetic_panic();
+    Ok(())
+}

--- a/support/src/lib.rs
+++ b/support/src/lib.rs
@@ -3,6 +3,7 @@
 //! Reports contain typed classifications, never formatted errors or panic payloads.
 //! Hosted delivery is intentionally absent until a TLS transport passes policy.
 
+mod stack;
 mod storage;
 mod ui;
 
@@ -181,6 +182,8 @@ impl Usage {
 #[serde(deny_unknown_fields)]
 struct Preferences {
     diagnostics: bool,
+    #[serde(default)]
+    backtraces: bool,
     usage: bool,
 }
 
@@ -188,6 +191,7 @@ impl Default for Preferences {
     fn default() -> Self {
         Self {
             diagnostics: true,
+            backtraces: false,
             usage: false,
         }
     }
@@ -203,13 +207,22 @@ struct Report {
     os: String,
     arch: String,
     payload: Payload,
+    #[serde(default)]
+    sentry_consent: bool,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 enum Payload {
-    Failure { kind: Failure, site: Option<Site> },
-    Usage { counters: Usage },
+    Failure {
+        kind: Failure,
+        site: Option<Site>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trace: Option<stack::Trace>,
+    },
+    Usage {
+        counters: Usage,
+    },
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -249,18 +262,19 @@ fn safe_source(file: &str) -> bool {
 impl Report {
     fn new(info: Info, payload: Payload) -> Self {
         Self {
-            schema: 1,
+            schema: 2,
             app: info.app,
             version: token(info.version).into(),
             revision: token(info.revision.unwrap_or("unknown")).into(),
             os: std::env::consts::OS.into(),
             arch: std::env::consts::ARCH.into(),
             payload,
+            sentry_consent: false,
         }
     }
 
     fn valid(&self, app: App) -> bool {
-        self.schema == 1
+        matches!(self.schema, 1 | 2)
             && self.app == app
             && token(&self.version) == self.version
             && token(&self.revision) == self.revision
@@ -271,9 +285,15 @@ impl Report {
             )
             && match self.payload {
                 Payload::Failure {
-                    site: Some(ref site),
+                    ref site,
+                    ref trace,
                     ..
-                } => safe_source(&site.file),
+                } => {
+                    site.as_ref().is_none_or(|site| safe_source(&site.file))
+                        && trace
+                            .as_ref()
+                            .is_none_or(|trace| self.schema == 2 && trace.valid())
+                }
                 _ => true,
             }
     }
@@ -292,6 +312,7 @@ struct State {
     reports: Vec<(path::PathBuf, Report)>,
     notice: Option<&'static str>,
     selected: usize,
+    sentry_review: Option<path::PathBuf>,
 }
 
 impl State {
@@ -300,6 +321,7 @@ impl State {
         if self.preferences.usage != preferences.usage {
             CONSENT.fetch_add(1, sync::atomic::Ordering::AcqRel);
         }
+        let remove_stacks = self.preferences.backtraces && !preferences.backtraces;
         self.preferences = preferences;
         DIAGNOSTICS.store(preferences.diagnostics, sync::atomic::Ordering::Release);
         USAGE.store(preferences.usage, sync::atomic::Ordering::Release);
@@ -307,15 +329,18 @@ impl State {
             self.usage = Usage::default();
         }
         if let Some(ref storage) = self.storage {
-            let result = storage
-                .preferences(preferences)
-                .and_then(|()| storage.purge_disabled(preferences));
+            let result = storage.preferences(preferences).and_then(|()| {
+                storage.purge_disabled(Preferences {
+                    diagnostics: preferences.diagnostics && !remove_stacks,
+                    ..preferences
+                })
+            });
             if result.is_err() {
                 self.notice =
                     Some("Could not persist privacy settings or remove every local report.");
             }
             self.reports.retain(|(_, report)| match report.payload {
-                Payload::Failure { .. } => preferences.diagnostics,
+                Payload::Failure { .. } => preferences.diagnostics && !remove_stacks,
                 Payload::Usage { .. } => preferences.usage,
             });
         }
@@ -325,7 +350,12 @@ impl State {
         if !self.preferences.diagnostics {
             return;
         }
-        let report = Report::new(self.info, Payload::Failure { kind, site });
+        let trace = self
+            .preferences
+            .backtraces
+            .then(stack::Trace::capture)
+            .flatten();
+        let report = Report::new(self.info, Payload::Failure { kind, site, trace });
         if let Some(ref storage) = self.storage {
             match storage.save(&report) {
                 Ok(path) => {
@@ -348,6 +378,7 @@ pub fn init(info: Info, directory: Option<path::PathBuf>) -> Session {
         .map(storage::Storage::load_preferences)
         .unwrap_or(Preferences {
             diagnostics: false,
+            backtraces: false,
             usage: false,
         });
     let reports = storage
@@ -362,6 +393,7 @@ pub fn init(info: Info, directory: Option<path::PathBuf>) -> Session {
         usage: Usage::default(),
         notice: None,
         selected: 0,
+        sentry_review: None,
     };
     if SUPPORT.set(sync::Mutex::new(state)).is_ok() {
         DIAGNOSTICS.store(preferences.diagnostics, sync::atomic::Ordering::Release);
@@ -542,6 +574,7 @@ mod tests {
             Payload::Failure {
                 kind: Failure::Panic,
                 site: None,
+                trace: None,
             },
         );
         assert!(!report.text().contains("CANARY"));
@@ -578,8 +611,36 @@ mod tests {
                 let mut state = mutex.lock().unwrap();
                 assert_eq!(state.reports.len(), 1);
                 assert!(!state.reports[0].1.text().contains("CANARY"));
+                assert!(matches!(
+                    state.reports[0].1.payload,
+                    Payload::Failure { trace: None, .. }
+                ));
+                state.save_preferences(Preferences {
+                    diagnostics: true,
+                    backtraces: true,
+                    usage: false,
+                });
+                state.record(Failure::Panic, None);
+                assert!(matches!(
+                    state.reports[0].1.payload,
+                    Payload::Failure { trace: Some(_), .. }
+                ));
+                assert!(!state.reports[0].1.text().contains("CANARY"));
+                state.save_preferences(Preferences {
+                    diagnostics: true,
+                    backtraces: false,
+                    usage: false,
+                });
+                assert!(state.reports.is_empty());
+                assert!(state.storage.as_ref().unwrap().reports().is_empty());
+                state.record(Failure::Panic, None);
+                assert!(matches!(
+                    state.reports[0].1.payload,
+                    Payload::Failure { trace: None, .. }
+                ));
                 state.save_preferences(Preferences {
                     diagnostics: false,
+                    backtraces: false,
                     usage: true,
                 });
             }
@@ -588,10 +649,12 @@ mod tests {
                 let mut state = mutex.lock().unwrap();
                 state.save_preferences(Preferences {
                     diagnostics: false,
+                    backtraces: false,
                     usage: false,
                 });
                 state.save_preferences(Preferences {
                     diagnostics: false,
+                    backtraces: false,
                     usage: true,
                 });
             }
@@ -605,6 +668,7 @@ mod tests {
                 assert_eq!(state.usage.histograms[0].iter().sum::<u64>(), 1);
                 state.save_preferences(Preferences {
                     diagnostics: false,
+                    backtraces: false,
                     usage: false,
                 });
             }

--- a/support/src/stack.rs
+++ b/support/src/stack.rs
@@ -1,0 +1,112 @@
+//! Address-only backtraces from the executable, never other loaded modules.
+use std::{path, sync};
+
+const MAX_FRAMES: usize = 48;
+const MAX_WALK: usize = 128;
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Trace {
+    debug_id: String,
+    code_id: Option<String>,
+    image_size: u64,
+    image_vmaddr: u64,
+    /// Oldest to newest, relative to the executable's load address (not ASLR addresses).
+    offsets: Vec<u64>,
+}
+
+struct Image {
+    base: u64,
+    trace: Trace,
+}
+
+impl Image {
+    fn load() -> Option<Self> {
+        let executable = std::env::current_exe().ok()?;
+        sentry_debug_images::debug_images()
+            .into_iter()
+            .find_map(|image| {
+                let sentry_core::protocol::DebugImage::Symbolic(image) = image else {
+                    return None;
+                };
+                if path::Path::new(&image.name) != executable {
+                    return None;
+                }
+                Some(Self {
+                    base: image.image_addr.0,
+                    trace: Trace {
+                        debug_id: image.id.to_string(),
+                        code_id: image.code_id.map(|id| id.to_string()),
+                        image_size: image.image_size,
+                        image_vmaddr: image.image_vmaddr.0,
+                        offsets: Vec::new(),
+                    },
+                })
+            })
+    }
+}
+
+impl Trace {
+    pub(crate) fn capture() -> Option<Self> {
+        // Called only after checking local backtrace consent. Do not resolve symbols
+        // in the failing process; the matching release symbols belong in Sentry.
+        static IMAGE: sync::OnceLock<Option<Image>> = sync::OnceLock::new();
+        let image = IMAGE.get_or_init(Image::load).as_ref()?;
+        let mut trace = image.trace.clone();
+        trace.offsets.reserve(MAX_FRAMES);
+        let mut visited = 0;
+        backtrace::trace(|frame| {
+            visited += 1;
+            if let Some(offset) = (frame.ip() as u64).checked_sub(image.base)
+                && offset < trace.image_size
+            {
+                trace.offsets.push(offset);
+            }
+            visited < MAX_WALK && trace.offsets.len() < MAX_FRAMES
+        });
+        trace.offsets.reverse();
+        trace.valid().then_some(trace)
+    }
+
+    pub(crate) fn valid(&self) -> bool {
+        self.debug_id.len() <= 45
+            && self.debug_id.parse::<sentry_core::types::DebugId>().is_ok()
+            && self.code_id.as_ref().is_none_or(|id| {
+                !id.is_empty() && id.len() <= 128 && id.bytes().all(|b| b.is_ascii_hexdigit())
+            })
+            && self.image_size > 0
+            && self.image_size <= 1 << 40
+            && !self.offsets.is_empty()
+            && self.offsets.len() <= MAX_FRAMES
+            && self.offsets.iter().all(|offset| *offset < self.image_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn captures_bounded_executable_offsets_without_paths() {
+        let trace = Trace::capture().expect("test executable has debug information");
+        assert!(trace.valid());
+        let json = serde_json::to_string(&trace).unwrap();
+        assert!(json.len() < 4096);
+        assert!(!json.contains(std::env::current_exe().unwrap().to_str().unwrap()));
+        assert!(!json.contains("name"));
+        assert!(!json.contains("image_addr"));
+    }
+
+    #[test]
+    fn rejects_untrusted_or_out_of_range_metadata() {
+        let mut trace = Trace::capture().unwrap();
+        trace.offsets.push(trace.image_size);
+        assert!(!trace.valid());
+        trace.offsets.pop();
+        trace.code_id = Some("/home/CANARY".into());
+        assert!(!trace.valid());
+        trace.code_id = None;
+        trace.debug_id = "CANARY".into();
+        assert!(!trace.valid());
+    }
+}

--- a/support/src/storage.rs
+++ b/support/src/storage.rs
@@ -89,11 +89,13 @@ impl Storage {
         match read_bounded(&self.root.join("preferences.json"), 512) {
             Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or(Preferences {
                 diagnostics: false,
+                backtraces: false,
                 usage: false,
             }),
             Err(ref error) if error.kind() == io::ErrorKind::NotFound => Preferences::default(),
             Err(_) => Preferences {
                 diagnostics: false,
+                backtraces: false,
                 usage: false,
             },
         }
@@ -260,6 +262,7 @@ mod tests {
             Payload::Failure {
                 kind: Failure::Panic,
                 site: None,
+                trace: None,
             },
         )
     }
@@ -306,6 +309,7 @@ mod tests {
             .unwrap();
         let prefs = Preferences {
             diagnostics: false,
+            backtraces: false,
             usage: true,
         };
         store.preferences(prefs).unwrap();
@@ -319,6 +323,7 @@ mod tests {
         store
             .purge_disabled(Preferences {
                 diagnostics: false,
+                backtraces: false,
                 usage: false,
             })
             .unwrap();
@@ -352,12 +357,14 @@ mod tests {
             storage: Some(store),
             preferences: Preferences {
                 diagnostics: false,
+                backtraces: false,
                 usage: false,
             },
             reports: Vec::new(),
             usage: Usage::default(),
             notice: None,
             selected: 0,
+            sentry_review: None,
         };
         state.record(Failure::Panic, None);
         assert!(state.storage.as_ref().unwrap().files().unwrap().is_empty());

--- a/support/src/ui.rs
+++ b/support/src/ui.rs
@@ -24,10 +24,13 @@ pub fn show(ui: &mut egui::Ui, info: Info) {
         let mut preferences = state.preferences;
         let diagnostics = ui.checkbox(&mut preferences.diagnostics, "Keep local failure reports").changed();
         ui.weak("Ask before sharing. No automatic uploads or memory dumps.");
+        let backtraces = ui.add_enabled(preferences.diagnostics,
+            egui::Checkbox::new(&mut preferences.backtraces, "Include application backtraces locally")).changed();
+        ui.weak("Off by default. Executable debug ID and code offsets only; no memory or loaded-library paths.");
         let usage = ui.checkbox(&mut preferences.usage, "Collect local usage statistics").changed();
         ui.weak("Off by default. Fixed feature flags and timing buckets; no installation ID.");
-        if diagnostics || usage { state.save_preferences(preferences); }
-        ui.weak("Turning either off clears its saved reports. Up to 8 local reports. Old reports are pruned on launch and when saving.");
+        if diagnostics || backtraces || usage { state.save_preferences(preferences); }
+        ui.weak("Turning a category off clears its reports; turning backtraces off clears failure reports. Up to 8 local reports. Old reports are pruned on launch and when saving.");
         if preferences.usage && ui.button("Review usage summary").clicked() {
             let report = Report::new(info, Payload::Usage { counters: state.usage.clone() });
             if let Some(ref storage) = state.storage {
@@ -47,10 +50,18 @@ pub fn show(ui: &mut egui::Ui, info: Info) {
             ui.horizontal_wrapped(|ui| {
                 ui.label("Local report");
                 let count = state.reports.len();
-                ui.add(egui::DragValue::new(&mut state.selected).range(0..=count-1));
+                if ui.add(egui::DragValue::new(&mut state.selected).range(0..=count-1)).changed() { state.sentry_review = None; }
                 ui.weak(format!("of {count} (0 is newest)"));
             });
-            let (path, report) = state.reports[state.selected].clone();
+            let (path, mut report) = state.reports[state.selected].clone();
+            if matches!(report.payload, Payload::Failure { trace: Some(_), .. }) {
+                let mut approved = state.sentry_review.as_ref() == Some(&path);
+                if ui.checkbox(&mut approved, "Allow Sentry processing of this report").changed() {
+                    state.sentry_review = approved.then(|| path.clone());
+                }
+                report.sentry_consent = approved;
+                ui.weak("Applies only to the report you copy or email. No automatic upload; Sentry is a third-party service.");
+            }
             let mut text = report.text();
             egui::ScrollArea::vertical().id_salt("report-preview").max_height(160.0).show(ui, |ui| {
                 ui.add(egui::TextEdit::multiline(&mut text).code_editor().interactive(false).desired_width(f32::INFINITY));


### PR DESCRIPTION
Add optional executable-only local backtraces, reviewed Sentry import, and release-symbol uploads.

- Backtraces are separately opt-in. Retain bounded relative code offsets and binary debug IDs, not panic payloads, ASLR bases, loaded-library paths or memory.
- Require per-report permission before private maintainer-side import. Validate a closed schema; dry runs perform no networking. No in-app HTTPS dependency or automatic upload.
- Preserve matching debug files for every release variant before packaging/signing. CI alone receives SENTRY_AUTH_TOKEN; org/project accept secrets or variables.
- Add a plain Crash diagnostics workflow. PR checks use isolated synthetic probes without credentials. Explicit dispatch on main additionally uploads probe symbols and events.

Validation: full normal CI and Crash diagnostics are green at e78db46c1fcc0fca770861b55daf36c83cbdcbba. Optimized probes capture frames on Linux/macOS/Windows; Linux and macOS resolve the actual panic frame to its source line. Windows validates capture and PDB retention; Sentry-side PDB resolution remains an acceptance check. Includes 18 support tests and 11 importer tests, plus Fileman's existing platform/SFTP/replay checks.

After merge, manually run Crash diagnostics on main and inspect all three synthetic Sentry events. HTTP acceptance alone is not symbolication. SENTRY.md documents the steps. Credentials, uploads and packaged-application crashes have not yet been validated end to end. Native crashes and automatic in-app delivery remain separate; the native-crypto policy is unchanged.