### PR TITLE
Abort remote image loads and preview small PNGs early

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1676,17 +1676,15 @@ impl AppState {
                 path: path::PathBuf::from("/"),
                 category: QuickJumpCategory::Remote,
             });
-            // Remote home (if we have a session with home_dir)
-            if let Some(session_arc) = self.sftp_sessions.get(&host) {
-                if let Ok(session) = session_arc.try_lock() {
-                    if let Some(ref home) = session.home_dir {
-                        entries.push(QuickJumpEntry {
-                            label: format!("{host}:~"),
-                            path: path::PathBuf::from(home),
-                            category: QuickJumpCategory::Remote,
-                        });
-                    }
-                }
+            if let Some(session_arc) = self.sftp_sessions.get(&host)
+                && let Ok(session) = session_arc.try_lock()
+                && let Some(ref home) = session.home_dir
+            {
+                entries.push(QuickJumpEntry {
+                    label: format!("{host}:~"),
+                    path: path::PathBuf::from(home),
+                    category: QuickJumpCategory::Remote,
+                });
             }
         }
 

--- a/src/image_decode.rs
+++ b/src/image_decode.rs
@@ -24,6 +24,15 @@ pub fn is_jpeg(bytes: &[u8]) -> bool {
     bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8
 }
 
+/// Whatever a prefix of the file can already show: JPEG EXIF thumbnail, or a
+/// complete small PNG/WebP/GIF. Truncated data returns `None`.
+pub fn decode_prefix_preview(bytes: &[u8], max_side: u32) -> Option<(DecodedImage, ImageMeta)> {
+    if is_jpeg(bytes) {
+        return decode_jpeg_exif_thumbnail(bytes, max_side);
+    }
+    decode_image_bytes(bytes, max_side)
+}
+
 /// Upper bound on decoded pixel count for the preview decoders that allocate
 /// straight from header dimensions. A crafted header can claim up to
 /// 65535×65535; without this cap that is a multi-gigabyte allocation / OOM from
@@ -1689,5 +1698,49 @@ mod jpeg_fuzz_tests {
             }
             let _ = decode_jpeg_dc_preview(&v, 256);
         }
+    }
+}
+
+#[cfg(test)]
+mod prefix_preview_tests {
+    use super::decode_prefix_preview;
+
+    fn is_png(bytes: &[u8]) -> bool {
+        bytes.len() >= 8 && bytes.starts_with(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A])
+    }
+
+    // 1×1 RGB PNG.
+    const TINY_PNG: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0xf8,
+        0xcf, 0xc0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0xf7, 0x03, 0x41, 0x43, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+
+    #[test]
+    fn detects_png() {
+        assert!(is_png(TINY_PNG));
+        assert!(!is_png(b"\x89PNG"));
+        assert!(!is_png(&[0xff, 0xd8]));
+    }
+
+    #[test]
+    fn complete_png_decodes_from_prefix() {
+        let (decoded, meta) = decode_prefix_preview(TINY_PNG, 256).expect("tiny png");
+        assert_eq!(meta.width, 1);
+        assert_eq!(meta.height, 1);
+        let super::DecodedImage::Static(img) = decoded else {
+            panic!("expected static image");
+        };
+        assert_eq!(img.width(), 1);
+        assert_eq!(img.height(), 1);
+    }
+
+    #[test]
+    fn truncated_png_does_not_panic() {
+        let _ = decode_prefix_preview(&TINY_PNG[..20], 256);
+        let _ = decode_prefix_preview(&TINY_PNG[..8], 256);
+        let _ = decode_prefix_preview(&TINY_PNG[..4], 256);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -625,6 +625,22 @@ pub(crate) fn handle_keyboard(
     let ctrl_p = !in_edit && ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::P));
     let ctrl_e = !in_edit && ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::E));
     let ctrl_n = !in_edit && ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::N));
+    // Shift variants before the bare Ctrl ones: consume_key(CTRL, M) also
+    // matches Ctrl+Shift+M on some platforms (macOS), which would Move.
+    let ctrl_shift_m = !in_edit
+        && ctx.input_mut(|i| {
+            i.consume_key(
+                egui::Modifiers::CTRL.plus(egui::Modifiers::SHIFT),
+                egui::Key::M,
+            )
+        });
+    let ctrl_shift_c = !in_edit
+        && ctx.input_mut(|i| {
+            i.consume_key(
+                egui::Modifiers::CTRL.plus(egui::Modifiers::SHIFT),
+                egui::Key::C,
+            )
+        });
     let ctrl_c = !in_edit
         && !search_typing
         && ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::C));
@@ -641,20 +657,6 @@ pub(crate) fn handle_keyboard(
         && !search_typing
         && ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::X));
     let ctrl_i = !in_edit && ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::I));
-    let ctrl_shift_m = !in_edit
-        && ctx.input_mut(|i| {
-            i.consume_key(
-                egui::Modifiers::CTRL.plus(egui::Modifiers::SHIFT),
-                egui::Key::M,
-            )
-        });
-    let ctrl_shift_c = !in_edit
-        && ctx.input_mut(|i| {
-            i.consume_key(
-                egui::Modifiers::CTRL.plus(egui::Modifiers::SHIFT),
-                egui::Key::C,
-            )
-        });
     let ctrl_shift_o = !in_edit
         && ctx.input_mut(|i| {
             i.consume_key(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3666,7 +3666,15 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
         let image_sftp = sftp_sessions_shared.clone();
         let image_progress = transfer_progress.clone();
         thread::spawn(move || {
-            while let Ok(mut req) = image_req_rx.recv() {
+            let mut pending: Option<ImageRequest> = None;
+            loop {
+                let mut req = match pending.take() {
+                    Some(req) => req,
+                    None => match image_req_rx.recv() {
+                        Ok(req) => req,
+                        Err(_) => break,
+                    },
+                };
                 // Skip stale requests; send cancellation so their pending state clears.
                 while let Ok(newer) = image_req_rx.try_recv() {
                     let _ = image_res_tx.send(ImageResponse::Err {
@@ -3676,69 +3684,99 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
                     req = newer;
                 }
 
-                // Remote sources: stream in two phases so the EXIF thumbnail
-                // can be sent before the full file has downloaded.
+                // Remote: do not hold the session mutex across the download, and
+                // abort if the user has already moved on to another file.
                 if let ImageSource::Remote { ref host, ref path } = req.source {
                     let key = req.key.clone();
+                    let host = host.clone();
+                    let path = path.clone();
                     let session = image_sftp
                         .lock()
                         .unwrap_or_else(|p| p.into_inner())
-                        .get(host)
+                        .get(&host)
                         .cloned();
-                    let data = session.and_then(|s| {
-                        let locked = s.lock().unwrap_or_else(|p| p.into_inner());
-                        let stat = locked.sftp.stat(path).ok();
-                        image_progress.reset(stat.and_then(|s| s.size).unwrap_or(0));
-                        let mut file =
-                            fileman::sftp::open_remote_reader(&locked.sftp, path).ok()?;
-                        let mut buf = Vec::new();
-                        let mut chunk = vec![0u8; 32 * 1024];
-                        // Phase 1: read header prefix; fire EXIF thumbnail immediately
-                        const EXIF_PREFIX: usize = 128 * 1024;
-                        while buf.len() < EXIF_PREFIX {
-                            match file.read(&mut chunk) {
-                                Ok(0) => break,
-                                Ok(n) => {
-                                    buf.extend_from_slice(&chunk[..n]);
-                                    image_progress.add(n as u64);
-                                }
-                                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-                                Err(_) => break,
-                            }
-                        }
-                        if image_decode::is_jpeg(&buf)
-                            && let Some((thumb, meta)) =
-                                image_decode::decode_jpeg_exif_thumbnail(&buf, MAX_TEXTURE_SIDE)
-                        {
-                            let _ = image_res_tx.send(ImageResponse::Ok(ImageResult {
-                                key: key.clone(),
-                                image: thumb,
-                                meta,
-                                refining: true,
-                            }));
-                        }
-                        // Phase 2: read the rest of the file
-                        loop {
-                            match file.read(&mut chunk) {
-                                Ok(0) => break,
-                                Ok(n) => {
-                                    buf.extend_from_slice(&chunk[..n]);
-                                    image_progress.add(n as u64);
-                                }
-                                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-                                Err(_) => break,
-                            }
-                        }
-                        Some(buf)
-                    });
-                    let Some(data) = data else {
+                    let conn =
+                        session.map(|s| s.lock().unwrap_or_else(|p| p.into_inner()).sftp.clone());
+                    let Some(conn) = conn else {
                         let _ = image_res_tx.send(ImageResponse::Err {
                             key: req.key,
                             message: "Failed to read image data".to_string(),
                         });
                         continue;
                     };
-                    // Tier 1 (EXIF) already sent above for JPEGs; dispatch tiers 2 & 3
+                    let stat = conn.stat(&path).ok();
+                    image_progress.reset(stat.and_then(|s| s.size).unwrap_or(0));
+                    let mut file = match fileman::sftp::open_remote_reader(&conn, &path) {
+                        Ok(f) => f,
+                        Err(_) => {
+                            let _ = image_res_tx.send(ImageResponse::Err {
+                                key: req.key,
+                                message: "Failed to read image data".to_string(),
+                            });
+                            continue;
+                        }
+                    };
+                    let mut buf = Vec::new();
+                    let mut chunk = vec![0u8; 32 * 1024];
+                    const PREFIX: usize = 128 * 1024;
+                    let mut tried_prefix = false;
+                    let mut aborted = None;
+                    loop {
+                        if let Ok(newer) = image_req_rx.try_recv() {
+                            aborted = Some(newer);
+                            break;
+                        }
+                        match file.read(&mut chunk) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                buf.extend_from_slice(&chunk[..n]);
+                                image_progress.add(n as u64);
+                            }
+                            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                            Err(_) => break,
+                        }
+                        if !tried_prefix && buf.len() >= PREFIX {
+                            tried_prefix = true;
+                            if let Some((image, meta)) =
+                                image_decode::decode_prefix_preview(&buf, MAX_TEXTURE_SIDE)
+                            {
+                                let _ = image_res_tx.send(ImageResponse::Ok(ImageResult {
+                                    key: key.clone(),
+                                    image,
+                                    meta,
+                                    refining: true,
+                                }));
+                            }
+                        }
+                    }
+                    if let Some(newer) = aborted {
+                        let _ = image_res_tx.send(ImageResponse::Err {
+                            key,
+                            message: String::new(),
+                        });
+                        pending = Some(newer);
+                        continue;
+                    }
+                    if !tried_prefix
+                        && !buf.is_empty()
+                        && let Some((image, meta)) =
+                            image_decode::decode_prefix_preview(&buf, MAX_TEXTURE_SIDE)
+                    {
+                        let _ = image_res_tx.send(ImageResponse::Ok(ImageResult {
+                            key: key.clone(),
+                            image,
+                            meta,
+                            refining: true,
+                        }));
+                    }
+                    if buf.is_empty() {
+                        let _ = image_res_tx.send(ImageResponse::Err {
+                            key: req.key,
+                            message: "Failed to read image data".to_string(),
+                        });
+                        continue;
+                    }
+                    let data = buf;
                     if image_decode::is_jpeg(&data) {
                         if let Some((dc, dc_meta)) =
                             image_decode::decode_jpeg_dc_preview(&data, MAX_TEXTURE_SIDE)

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1329,19 +1329,39 @@ pub struct ConnectParams {
 pub fn connect(params: ConnectParams) -> SshResult<Conn> {
     let mut session = open_session(&params)?;
 
-    // The remote home directory, if the server will tell us.
+    // SFTP cwd after login is usually the account home. Some servers do not
+    // implement realpath, or start in `/`; a shell `pwd` fills those gaps.
     let home_dir = match session.sftp.realpath(".") {
-        Ok(_) => session.one_name("realpath .").ok(),
+        Ok(_) => session
+            .one_name("realpath .")
+            .ok()
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty() && p != "." && p != "./"),
         Err(_) => None,
     };
 
-    Ok(Conn {
+    let mut conn = Conn {
         session: Mutex::new(session),
         alive: Arc::new(AtomicBool::new(true)),
         host: params.host.clone(),
         home_dir,
         params,
-    })
+    };
+    if conn.home_dir.as_deref().is_none_or(|p| p == "/")
+        && let Ok(out) = conn.exec("pwd")
+    {
+        let p = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if !p.is_empty() && p != "/" && p != "." {
+            conn.home_dir = Some(p);
+        }
+    }
+
+    Ok(conn)
 }
 
 /// Dials, authenticates, and gets the SFTP subsystem talking.

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -1042,8 +1042,8 @@ pub fn start_preview_worker(
                             let force_text = is_text_name(&path);
                             let session = lock_or_recover(&sftp_sessions).get(&host).cloned();
                             if let Some(session) = session {
-                                let locked = lock_or_recover(&session);
-                                match crate::sftp::open_remote_reader(&locked.sftp, &path) {
+                                let conn = lock_or_recover(&session).sftp.clone();
+                                match crate::sftp::open_remote_reader(&conn, &path) {
                                     Ok(reader) => {
                                         if let Err(err) = send_streaming_preview(
                                             &result_tx,

--- a/tests/sftp_localhost.rs
+++ b/tests/sftp_localhost.rs
@@ -21,6 +21,9 @@ fn sftp_connect() {
     let session = connect_localhost();
     assert_eq!(session.host, "localhost");
     assert!(session.is_alive());
+    let home = session.home_dir.expect("remote home from realpath or pwd");
+    assert!(home.starts_with('/'), "home should be absolute: {home}");
+    assert_ne!(home, "/");
 }
 
 #[test]


### PR DESCRIPTION
Do not hold the SFTP session while downloading a preview; a newer selection cancels the read. Try decoding after 128 KB so small PNGs appear before the rest of the file. Consume Ctrl+Shift+M before Ctrl+M. Resolve remote home via pwd when realpath is missing or `/`.