### PR TITLE
Clip preview to its pane so it cannot paint over the listing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4427,6 +4427,7 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
 
                         if !right_editing {
                             ui.scope_builder(egui::UiBuilder::new().max_rect(left_rect), |ui| {
+                                ui.set_clip_rect(left_rect);
                                 if left_editing {
                                     let is_focused =
                                         runtime.app.active_panel == core::ActivePanel::Left;
@@ -4501,6 +4502,7 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
                         }
                         if !left_editing {
                             ui.scope_builder(egui::UiBuilder::new().max_rect(right_rect), |ui| {
+                                ui.set_clip_rect(right_rect);
                                 if right_editing {
                                     let is_focused =
                                         runtime.app.active_panel == core::ActivePanel::Right;
@@ -4992,6 +4994,7 @@ fn draw_root_ui(render: UiRender<'_>) {
         if !right_editing {
             ui_cache.left_rows = ui
                 .scope_builder(egui::UiBuilder::new().max_rect(left_rect), |ui| {
+                    ui.set_clip_rect(left_rect);
                     if left_editing {
                         let is_focused = app.active_panel == core::ActivePanel::Left;
                         let theme = app.theme.clone();
@@ -5063,6 +5066,7 @@ fn draw_root_ui(render: UiRender<'_>) {
         if !left_editing {
             ui_cache.right_rows = ui
                 .scope_builder(egui::UiBuilder::new().max_rect(right_rect), |ui| {
+                    ui.set_clip_rect(right_rect);
                     if right_editing {
                         let is_focused = app.active_panel == core::ActivePanel::Right;
                         let theme = app.theme.clone();

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -30,6 +30,7 @@ pub fn draw_editor(ui: &mut egui::Ui, ctx: EditorRender<'_>) {
     let colors = theme.colors();
     ui.push_id("editor_panel", |ui| {
         egui::Frame::NONE
+            .fill(color32(colors.preview_bg))
             .stroke(egui::Stroke::new(
                 1.0_f32,
                 color32(if is_focused {

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -119,6 +119,7 @@ pub fn draw_preview(ui: &mut egui::Ui, ctx: PreviewRender<'_>) {
 
     ui.push_id("preview_panel", |ui| {
         egui::Frame::NONE
+            .fill(color32(colors.preview_bg))
             .stroke(egui::Stroke::new(
                 1.0_f32,
                 color32(if is_focused {


### PR DESCRIPTION
The Find bar and unwrapped text spilled across the split. Fill the preview/editor background the same way Help already does.